### PR TITLE
External intervalometer mode fix and debugging updates

### DIFF
--- a/Firmware/Motion_Engine/DFMoco.ino
+++ b/Firmware/Motion_Engine/DFMoco.ino
@@ -608,6 +608,8 @@ void df_setup()
 #if (DFBOARD == NMX)
     motors[i].stepPin = nmx_step_pins[i];
     motors[i].dirPin = nmx_dir_pins[i];
+	//for (byte i = 0; i < MOTOR_COUNT; i++)
+	//	motor[i].ms(4);
     pinMode(nmx_en_pins[i], OUTPUT);
     enableMotor(i, false);
 #else

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -107,7 +107,6 @@ const byte FLASH_DELAY				= 250;				// Time between flashes in milliseconds
 const unsigned int START_RST_TM		= 5000;				// # of milliseconds PBT must be held low to do a factory reset
 uint8_t debug_led_enable			= false;			// Debug led state
 uint8_t timing_master				= true;				// Do we generate timing for all devices on the network? i.e. -are we the timing master?
-unsigned long loop_time				= 0;				// Timing variable used for triggering events within loop()
 bool graffik_mode					= false;			// Indicates whether the controller is currently communicating with the Graffik application
 bool df_mode						= false;			// Indicates whether DragonFrame mode is enabled
 
@@ -286,13 +285,13 @@ Debugging Constants and Associated Flags
 ****************************************/
 
 
-byte usb_debug = B00000000;
-const byte DB_COM_OUT = B00000001;
-const byte DB_STEPS = B00000010;
-const byte DB_MOTOR = B00000100;
-const byte DB_GEN_SER = B00010000;
-const byte DB_FUNCT = B00100000;
-const byte DB_CONFIRM = B01000000;
+byte usb_debug			= B00000000;
+const byte DB_COM_OUT	= B00000001;
+const byte DB_STEPS		= B00000010;
+const byte DB_MOTOR		= B00000100;
+const byte DB_GEN_SER	= B00010000;
+const byte DB_FUNCT		= B00100000;
+const byte DB_CONFIRM	= B01000000;
 
 
 /***************************************
@@ -343,10 +342,8 @@ void setup() {
 	// Start Bluetooth communications
 	altSerial.begin(9600);
 
-	loop_time = millis();
-
 	if (usb_debug & DB_FUNCT)
-	USBSerial.println("Done setting things up!");
+	USBSerial.println("setup() - Done setting things up!");
   
 	// Set controller I/O pin modes
 	pinMode(DEBUG_PIN, OUTPUT);
@@ -440,32 +437,44 @@ void setup() {
 
 void loop() {
 
-	static unsigned long estop_time; // Remembers last time eStop was NOT pressed
-		if (df_mode) {
-		df_loop();
-		return;
-	}
-	
-	// If eStop button has been held more than 5 sec, switch to DF mode
-	if (digitalRead(ESTOP_PIN) == HIGH)
-		 estop_time = millis();
-	else if (!df_mode && millis() - estop_time > 5000) {
-		df_setup();
-		df_mode = true;
-		return;
-		
-	}
+	static unsigned long estop_time = 0; // Remembers last time eStop was NOT pressed
+	static unsigned long df_time = 0;
+	static unsigned long debug_time = 0;
 
 	// check to see if we have any commands waiting      
 	Node.check();
 	NodeBlue.check();
 	NodeUSB.check();
 
-	// If the the DB_STEPS debug flag is true, print diagnostic info
-	if ((millis() - loop_time) > 500 && (usb_debug & DB_STEPS))
+	// Only do these things every 100ms so we don't waste cycles during every loop
+	if ((millis() - df_time) > 100) {
+
+		// If eStop button has been held more than 3 sec, switch to DF mode
+		if (digitalRead(ESTOP_PIN) == HIGH)
+			estop_time = millis();
+		else if (!df_mode && millis() - estop_time > 3000) {
+			ledChase(2);
+			//USBSerial.print("Entering DF mode");
+			df_mode = true;
+			return;
+		}
+		//USBSerial.println(millis() - estop_time);
+			
+		// If the the DB_STEPS debug flag is true, print diagnostic info
+		if (df_mode) {
+			df_setup();
+			df_loop();
+			return;
+		}
+		df_time = millis();
+	}	
+
+	if ((usb_debug & DB_STEPS) && (millis() - debug_time) > 500) {
 		motorDebug();
-		
-	loop_time = millis();
+		debug_time = millis();
+	}
+
+	
 	
 	//Stop the motors if they're running and the watchdog timeout (time since last received command) has been exceeded
 	if ((motor[0].running() || motor[1].running() || motor[2].running()) && watchdog){
@@ -580,12 +589,11 @@ void eStop() {
 	static unsigned long last_interrupt_time = 0;
 	unsigned long interrupt_time = millis();
 
-	static unsigned long times_since_press = millis();
 	static byte enable_count = 0;
 	const byte THRESHOLD = 3;
 
 	// If interrupts come faster than 200ms, assume it's a bounce and ignore
-	if (interrupt_time - last_interrupt_time > 200) {
+	if (interrupt_time - last_interrupt_time > 150) {
 
 		if (running && !camera_test_mode)
 			stopProgram();	// This previously paused the running program, but that caused weird state issues with the mobile app
@@ -595,12 +603,15 @@ void eStop() {
 
 		else if (!motor[0].running() && !motor[1].running() && !motor[2].running()) {
 			// If the button was pressed recently enough, increase the enable count, otherwise reset it to 0.
-			if (millis() - times_since_press < 1500)
+			if (interrupt_time - last_interrupt_time < 1000)
 				enable_count++;
 			else
 				enable_count = 1;
-			//USBSerial.print("Switch count ");
-			//USBSerial.println(_enable_count);
+
+			if (usb_debug & DB_FUNCT){
+				USBSerial.print("eStop() - Switch count ");
+				USBSerial.println(enable_count);
+			}
 
 			// If the user has pressed the e-stop enough times within the alloted time span, enabled the external intervalometer
 			if (enable_count >= THRESHOLD && !external_intervalometer) {
@@ -622,7 +633,6 @@ void eStop() {
 				// Turn the debug light off to confirm the setting
 				debugOff();
 			}
-			loop_time = millis();
 		}
 
 		else
@@ -703,7 +713,7 @@ unsigned long totalProgramTime() {
 			if (motor[i].planType() == SMS) {
 				motor_time = Camera.interval * (motor[i].planLeadIn() + motor[i].planTravelLength() + motor[i].planLeadOut());
 				if (usb_debug & DB_FUNCT){
-					USBSerial.print("Interval: ");
+					USBSerial.print("totalProgramTime() - Interval: ");
 					USBSerial.print(Camera.interval);
 					USBSerial.print("  Lead in: ");
 					USBSerial.print(motor[i].planLeadIn());
@@ -766,6 +776,48 @@ void flasher(byte pin, int count) {
       delay(250); 
    }
    
+}
+
+/*
+void ledChase(byte p_chases)
+
+Wipes LEDs forward and back a specified number of times. Can be used as an indicator,
+but if holding position is critical, be aware that motors will be briefly put into sleep mode.
+
+*/
+
+void ledChase(byte p_chases) {
+	
+	bool current_sleep[MOTOR_COUNT];
+	
+	for (byte i = 0; i < MOTOR_COUNT; i++) {
+		// Save the current sleep state of all the motors so they can be restored later
+		current_sleep[i] = motor[i].sleep();
+		// Put them into sleep mode in case it isn't already
+		motor[i].sleep(true);
+	}
+
+	for (byte chase_count = 0; chase_count < p_chases; chase_count++) {
+		int bounce_count = p_chases * MOTOR_COUNT;
+		int current_motor = 0;
+		int chase_dir = 1;
+		
+		for (int i = 0; i < bounce_count; i++){
+			motor[current_motor].sleep(false);
+			delay(75);
+			motor[current_motor].sleep(true);
+			current_motor += chase_dir;
+			
+			// Change direction when at the last LED
+			if (current_motor == MOTOR_COUNT)
+				chase_dir *= -1;
+
+		}
+	}
+	// Restore the motor sleep states
+	for (byte i = 0; i < MOTOR_COUNT; i++) {
+		motor[i].sleep(current_sleep[i]);
+	}
 }
 
 

--- a/Firmware/Motion_Engine/OM_Camera_Control.ino
+++ b/Firmware/Motion_Engine/OM_Camera_Control.ino
@@ -68,11 +68,13 @@ void camCallBack(byte code) {
   // which can result in unexpected behavior
   
   if( code == OM_CAM_FFIN ) {
-	  USBSerial.println("camCallBack() - Entering exposure state");
-    Engine.state(ST_EXP);
+	  if (usb_debug & DB_FUNCT)
+		USBSerial.println("camCallBack() - Entering exposure state");
+	  Engine.state(ST_EXP);
   }
   else if( code == OM_CAM_EFIN ) {
-    USBSerial.println("camCallBack() - Entering wait state");
+	if (usb_debug & DB_FUNCT)
+	  USBSerial.println("camCallBack() - Entering wait state");
 	camera_fired++;
     Engine.state(ST_WAIT);
   }

--- a/Firmware/Motion_Engine/OM_Camera_Control.ino
+++ b/Firmware/Motion_Engine/OM_Camera_Control.ino
@@ -68,10 +68,12 @@ void camCallBack(byte code) {
   // which can result in unexpected behavior
   
   if( code == OM_CAM_FFIN ) {
+	  USBSerial.println("camCallBack() - Entering exposure state");
     Engine.state(ST_EXP);
   }
   else if( code == OM_CAM_EFIN ) {
-    camera_fired++;
+    USBSerial.println("camCallBack() - Entering wait state");
+	camera_fired++;
     Engine.state(ST_WAIT);
   }
   else if( code == OM_CAM_WFIN ) {

--- a/Firmware/Motion_Engine/OM_ControlCycle.ino
+++ b/Firmware/Motion_Engine/OM_ControlCycle.ino
@@ -126,12 +126,9 @@ void cycleCamera() {
 
 		//else if (key_move && current_frame >= key_frames)
 		//	current_frame = 0;
+  	   //}
   
-	// if in external interval mode, don't do anything if a force shot isn't registered
-  //if (usb_debug & DB_FUNCT){
-	 // USBSerial.print("cycleCamera() - altForceShot state: ");
-	 // USBSerial.println(altForceShot);
-  //}
+  // if in external interval mode, don't do anything if a force shot isn't registered
   if (altExtInt && !altForceShot) {
 	  if (usb_debug & DB_FUNCT)
 		USBSerial.println("cycleCamera() - Skipping shot, waiting for external trigger");
@@ -198,8 +195,6 @@ void cycleCamera() {
     } 
     
   }
-
-  //USBSerial.println("cycleCamera() - End of function");
   
 }
 
@@ -325,9 +320,9 @@ void cycleCheckMotor() {
         
         // if autopause is enabled then pause upon completion of movement
       if( motor[0].autoPause == true || motor[1].autoPause == true || motor[2].autoPause == true ) {
-		  if (usb_debug & DB_GEN_SER)
-		  USBSerial.println("Auto pausing!!!");
-            pauseProgram();
+		  if (usb_debug & DB_FUNCT)
+			USBSerial.println("Auto pausing!!!");
+          pauseProgram();
       }
     }
     else { 

--- a/Firmware/Motion_Engine/OM_ControlCycle.ino
+++ b/Firmware/Motion_Engine/OM_ControlCycle.ino
@@ -128,10 +128,10 @@ void cycleCamera() {
 		//	current_frame = 0;
   
 	// if in external interval mode, don't do anything if a force shot isn't registered
-  if (usb_debug & DB_FUNCT){
-	  USBSerial.println("cycleCamera() - altForceShot state: ");
-	  USBSerial.print(altForceShot);
-  }
+  //if (usb_debug & DB_FUNCT){
+	 // USBSerial.print("cycleCamera() - altForceShot state: ");
+	 // USBSerial.println(altForceShot);
+  //}
   if (altExtInt && !altForceShot) {
 	  if (usb_debug & DB_FUNCT)
 		USBSerial.println("cycleCamera() - Skipping shot, waiting for external trigger");
@@ -151,7 +151,7 @@ void cycleCamera() {
     // if enough time has passed, and we're ok to take an exposure
     // note: for slaves, we only get here by a master signal, so we don't check interval timing
 
-  if( ComMgr.master() == false || ( millis() - camera_tm ) >= Camera.interval || !Camera.enable  ) {
+  if( ComMgr.master() == false || ( millis() - camera_tm ) >= Camera.interval || !Camera.enable || external_intervalometer ) {
 
 	  if (usb_debug & DB_FUNCT){
 		  USBSerial.print("cycleCamera() - Shots: ");
@@ -182,14 +182,16 @@ void cycleCamera() {
       // callback executions that will walk us through the complete exposure cycle.
       // -- if no focus is configured, nothing will happen but trigger
       // the callback that will trigger exposing the camera immediately
-	if (usb_debug & DB_FUNCT)
-		  USBSerial.println("cycleCamera() - Resetting altForceShot");
+	if (usb_debug & DB_FUNCT){
+		USBSerial.print("cycleCamera() - Camera busy: ");
+		USBSerial.print(Camera.busy());
+	}
     if( ! Camera.busy() ) {
-        // only execute cycle if the camera is not currently busy
+		if (usb_debug & DB_FUNCT)
+			USBSerial.println("cycleCamera() - Initiating exposure cycle");
+      // only execute cycle if the camera is not currently busy
       Engine.state(ST_BLOCK);
 	  altBlock = ALT_OFF;
-	  if (usb_debug & DB_FUNCT)
-		  USBSerial.println("cycleCamera() - Resetting altForceShot");
 	  altForceShot = false;
       camera_tm = millis();  
       Camera.focus();
@@ -197,7 +199,7 @@ void cycleCamera() {
     
   }
 
-  USBSerial.println("cycleCamera() - End of function");
+  //USBSerial.println("cycleCamera() - End of function");
   
 }
 

--- a/Firmware/Motion_Engine/OM_LimitHandler.ino
+++ b/Firmware/Motion_Engine/OM_LimitHandler.ino
@@ -116,7 +116,7 @@ void altHandler(byte p_which) {
     else if( altInputs[p_which] == ALT_EXTINT ) {
         
 		if (usb_debug & DB_GEN_SER)
-		USBSerial.println("External trigger detected");
+			USBSerial.println("External trigger detected");
 		
 		// set camera ok to fire
         altForceShot = true;

--- a/Firmware/Motion_Engine/OM_MotorMaster.ino
+++ b/Firmware/Motion_Engine/OM_MotorMaster.ino
@@ -190,7 +190,7 @@ void stopAllMotors() {
 
       // signal completion
       _fireCallback(OM_MOT_DONE);
-                  // let go of interrupt cycle
+      // let go of interrupt cycle
       Timer1.detachInterrupt();
 
 }

--- a/Firmware/Motion_Engine/OM_Motor_Control.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Control.ino
@@ -159,8 +159,6 @@ void startProgramCom() {
 		// Reset the program completion flag
 		program_complete = false;
 
-		//USBSerial.println("Start Break 1");
-
 		uint8_t wait_required = false;
 
 		// Check each motor to see if it needs backlash compensation
@@ -203,7 +201,7 @@ void startProgramCom() {
 
 		// When starting an SMS move, if we're only making small moves, set each motor's speed no faster than necessary to produce the smoothest motion possible
 		if (motor[1].planType() == SMS) {
-			////USBSerial.println("Start Break 4");
+			
 			// Determine the max time in seconds allowed for moving the motors
 			float max_move_time = (Camera.interval - Camera.triggerTime() - Camera.delayTime() - Camera.focusTime()) / MILLIS_PER_SECOND;
 			// If there's lots of time for moving, only use 1 second so we don't waste battery life getting to the destination
@@ -233,7 +231,7 @@ void startProgramCom() {
 	// Don't start a new program if one is already running
 	if (!running) {
 
-		if (usb_debug & DB_GEN_SER){
+		if (usb_debug & DB_FUNCT){
 			USBSerial.println("Motor distances:");
 			for (byte i = 0; i < MOTOR_COUNT; i++){
 				USBSerial.println(motor[i].stopPos() - motor[i].currentPos());
@@ -261,8 +259,6 @@ void startProgramCom() {
 			for (byte i = 0; i < MOTOR_COUNT; i++){
 				if (motor[i].enable())
 					motor[i].resumeMove();
-				//USBSerial.print("New Run Time: ");
-				//USBSerial.println(motor[i].planTravelLength());
 			}
 		}
 
@@ -367,7 +363,8 @@ byte validateProgram(byte p_motor, bool p_autosteps) {
 	// Check the comparison speed against the cutoff values and select the appropriate microstepping setting
 	// If the requested speed is too high, send error value, don't change microstepping setting
 	if (comparison_speed >= MAX_CUTOFF ) {
-		//USBSerial.println("Excessive speed requested");
+		if (usb_debug & DB_FUNCT)
+			USBSerial.println("Excessive speed requested");
 		return 0;
 	}
 	else {
@@ -418,7 +415,7 @@ byte msAutoSet(uint8_t p_motor) {
 		OMEEPROM::write(EE_MS_0 + (p_motor * EE_MOTOR_MEMORY_SPACE), microsteps);
 
 		// USB print the debug value, if necessary
-		if (usb_debug & DB_GEN_SER){
+		if (usb_debug & DB_FUNCT){
 			USBSerial.print("Requested Microsteps: ");
 			USBSerial.println(microsteps);
 			USBSerial.println("Microsteps successfully set");
@@ -429,7 +426,7 @@ byte msAutoSet(uint8_t p_motor) {
 
 	// If the motor or program is running and a report is requested, return 0 to indicate that the auto-set routine was not completed
 	else {
-		if (usb_debug & DB_GEN_SER)
+		if (usb_debug & DB_FUNCT)
 				USBSerial.println("Motors are running, can't auto-set microsteps");
 			return false;
 	}

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -612,7 +612,7 @@ void serMain(byte command, byte* input_serial_buffer) {
 				else
 					status = 0;
 				if (usb_debug & DB_GEN_SER){
-					USBSerial.print("Run Status: ");
+					USBSerial.print("Command Gen.101 - Run Status: ");
 					USBSerial.println(status);
 				}
 				response(true, status);
@@ -622,7 +622,7 @@ void serMain(byte command, byte* input_serial_buffer) {
     //Command 102 reads current run time. If the program has completed, it will return the run time when the program stopped.
 	case 102:
 		if (usb_debug & DB_GEN_SER){
-			USBSerial.print("Run time: ");
+			USBSerial.print("Command Gen.102 - Run time: ");
 			USBSerial.println (last_run_time);
 		}
 		if (external_intervalometer)
@@ -778,7 +778,7 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 125 returns the total run time of the current program in milliseconds
 	case 125:
 		if (usb_debug & DB_GEN_SER){
-			USBSerial.print("Total run time: ");
+			USBSerial.print("Command Gen.125 - Total run time: ");
 			USBSerial.println(totalProgramTime());
 			USBSerial.println("");
 		}
@@ -1082,7 +1082,8 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 
 			   // how many steps to take
 			   unsigned long steps = Node.ntoul(input_serial_buffer);
-
+			   USBSerial.print("Commanded steps: ");
+			   USBSerial.println(steps);
 			   // move
 			   if (steps == 0)
 				 motor[subaddr - 1].continuous(true);
@@ -1392,7 +1393,7 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 	case 107:
 		response(true, motor[subaddr - 1].running());
 		if (usb_debug & DB_GEN_SER){
-			USBSerial.print("Motor running? ");
+			USBSerial.print("Command gen.107 - Motor running? ");
 			USBSerial.println(motor[subaddr - 1].running());
 		}
 		break;
@@ -1592,7 +1593,7 @@ void serCamera(byte subaddr, byte command, byte* input_serial_buffer) {
 	case 109:
 		response(true, camera_fired);
 		if (usb_debug & DB_GEN_SER){
-			USBSerial.print("Camera fired: ");
+			USBSerial.print("Command Cam.109 - Camera fired: ");
 			USBSerial.println(camera_fired);
 		}
 		break;


### PR DESCRIPTION
#### Change Log

* Responsiveness of detection of button presses to enter external intervalometer mode improved
* In external intervalometer mode
 * motors now always run at top speed in 8th stepping mode
 * set interval is ignored and a a new move can be triggered as soon as motors have completed their SMS move
* USB debug improvements
 * Many more debug message locations added
 * All debug messages are now controlled via debugging flags and can be toggled through the debug setting serial command
 * Most debug messages include the function name of where they are originating for easier tracking
