### PR TITLE
Backlash uptake bug

### DIFF
--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -435,7 +435,7 @@ void setup() {
   
 	// defaults for motor
 	for( int i = 0; i < MOTOR_COUNT; i++){
-		motor[i].enable(false);
+		motor[i].enable(true);
 		motor[i].maxStepRate(MOT_DEFAULT_MAX_STEP);
 		motor[i].contSpeed(MOT_DEFAULT_MAX_SPD);
 		motor[i].contAccel(MOT_DEFAULT_CONT_ACCEL);

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -368,9 +368,8 @@ void setup() {
   
 	// Start Bluetooth communications
 	altSerial.begin(9600);
-
-	if (usb_debug & DB_FUNCT)
-		USBSerial.println("setup() - Done setting things up!");
+		
+	debugFunctln("setup() - Done setting things up!");
   
 	// Set controller I/O pin modes
 	pinMode(DEBUG_PIN, OUTPUT);
@@ -490,8 +489,8 @@ void loop() {
 			estop_time = millis();
 		else if (!df_mode && millis() - estop_time > 3000) {
 			ledChase(2);
-			if (usb_debug & DB_FUNCT)
-				USBSerial.print("Entering DF mode");
+			
+			debugFunct("Entering DF mode");
 			// Change motors to 8th stepping before starting DF mode
 			for (byte i = 0; i < MOTOR_COUNT; i++){
 				motor[i].ms(8);
@@ -680,11 +679,10 @@ void eStop() {
 				enable_count++;
 			else
 				enable_count = 1;
-
-			if (usb_debug & DB_FUNCT){
-				USBSerial.print("eStop() - Switch count ");
-				USBSerial.println(enable_count);
-			}
+						
+			debugFunct("eStop() - Switch count ");
+			debugFunctln((int)enable_count);
+			
 
 			// If the user has pressed the e-stop enough times within the alloted time span, enabled the external intervalometer
 			if (enable_count >= THRESHOLD && !external_intervalometer) {
@@ -787,24 +785,24 @@ unsigned long totalProgramTime() {
 			// SMS: Total the exposures for the program and multiply by the interval
 			if (motor[i].planType() == SMS) {
 				motor_time = Camera.intervalTime() * (motor[i].planLeadIn() + motor[i].planTravelLength() + motor[i].planLeadOut());
-				if (usb_debug & DB_FUNCT){				
-					USBSerial.print("totalProgramTime() - Motor: ");
-					USBSerial.print(i);
-					USBSerial.print(" Interval: ");
-					USBSerial.print(Camera.intervalTime());
-					USBSerial.print("  Lead in: ");
-					USBSerial.print(motor[i].planLeadIn());
-					USBSerial.print("  Accel: ");
-					USBSerial.print(motor[i].planAccelLength());
-					USBSerial.print("  Travel: ");
-					USBSerial.print(motor[i].planTravelLength());
-					USBSerial.print("  Decel: ");
-					USBSerial.print(motor[i].planDecelLength());
-					USBSerial.print("  Lead out: ");
-					USBSerial.print(motor[i].planLeadOut());
-					USBSerial.print("  Motor time: ");
-					USBSerial.println(motor_time);
-				}
+				
+				debugFunct("totalProgramTime() - Motor: ");
+				debugFunct((int)i);
+				debugFunct(" Interval: ");
+				debugFunct(Camera.intervalTime());
+				debugFunct("  Lead in: ");
+				debugFunct(motor[i].planLeadIn());
+				debugFunct("  Accel: ");
+				debugFunct(motor[i].planAccelLength());
+				debugFunct("  Travel: ");
+				debugFunct(motor[i].planTravelLength());
+				debugFunct("  Decel: ");
+				debugFunct(motor[i].planDecelLength());
+				debugFunct("  Lead out: ");
+				debugFunct(motor[i].planLeadOut());
+				debugFunct("  Motor time: ");
+				debugFunctln(motor_time);
+				
 			}
 			// CONT_TL AND CONT_VID: all segments are in milliseconds, no need to multiply anything
 			else
@@ -931,7 +929,7 @@ uint8_t checkMotorAttach() {
 		motor[i].sleep(true);
 	}
 
-	for (byte i = 0; i < MOTOR_COUNT; i++) {
+	for (int i = 0; i < MOTOR_COUNT; i++) {
 		motor[i].sleep(false);
 		delay(100);
 		// Read the analog value from current sensing pin
@@ -945,12 +943,12 @@ uint8_t checkMotorAttach() {
 			attached |= (1 << i);
 		// Put the motor back to sleep so it doesn't interfere with reading of the next motor
 		motor[i].sleep(true);
-		if (usb_debug & DB_FUNCT) {
-			USBSerial.print("Motor ");
-			USBSerial.print(i);
-			USBSerial.print(" current draw: ");
-			USBSerial.println(amps);
-		}
+		
+		debugFunct("Motor ");
+		debugFunct(i);
+		debugFunct(" current draw: ");
+		debugFunctln(amps);
+		
 	}
 
 	// Restore the saved sleep states
@@ -1064,6 +1062,12 @@ bool appMode() {
 	return app_mode;
 }
 
+void debugFunct(byte val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.print(val);
+	}
+}
+
 void debugFunct(int val){
 	if (usb_debug & DB_FUNCT){
 		USBSerial.print(val);
@@ -1091,6 +1095,12 @@ void debugFunct(long val){
 void debugFunct(String msg){
 	if (usb_debug & DB_FUNCT){
 		USBSerial.print(msg);
+	}
+}
+
+void debugFunctln(byte val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.println(val);
 	}
 }
 
@@ -1123,3 +1133,4 @@ void debugFunctln(String msg){
 		USBSerial.println(msg);
 	}
 }
+

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -1063,3 +1063,63 @@ void appMode(bool p_setting) {
 bool appMode() {
 	return app_mode;
 }
+
+void debugFunct(int val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.print(val);
+	}
+}
+
+void debugFunct(float val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.print(val);
+	}
+}
+
+void debugFunct(unsigned long val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.print(val);
+	}
+}
+
+void debugFunct(long val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.print(val);
+	}
+}
+
+void debugFunct(String msg){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.print(msg);
+	}
+}
+
+void debugFunctln(int val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.println(val);
+	}
+}
+
+void debugFunctln(float val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.println(val);
+	}
+}
+
+void debugFunctln(unsigned long val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.println(val);
+	}
+}
+
+void debugFunctln(long val){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.println(val);
+	}
+}
+
+void debugFunctln(String msg){
+	if (usb_debug & DB_FUNCT){
+		USBSerial.println(msg);
+	}
+}

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -514,6 +514,13 @@ void loop() {
 		debug_time = millis();
 	}
 
+	// Print debug information if necessary
+	if ((millis() - debug_time) > 5000) {
+		//motorDebug();
+		debug_time = millis();
+		USBSerial.println("Controller still alive");
+	}
+
 		
 	//Stop the motors if they're running, watchdog is active, and time since last received command has exceeded timeout
 	if (watchdog && (millis() - commandTime > WATCHDOG_MAX_TIME)){

--- a/Firmware/Motion_Engine/OM_Camera_Control.ino
+++ b/Firmware/Motion_Engine/OM_Camera_Control.ino
@@ -67,14 +67,12 @@ void camCallBack(byte code) {
   // function is called in an interrupt and can daisy-chain under certain configurations,
   // which can result in unexpected behavior
   
-  if( code == OM_CAM_FFIN ) {
-	  if (usb_debug & DB_FUNCT)
-		USBSerial.println("camCallBack() - Entering exposure state");
+  if( code == OM_CAM_FFIN ) {	  
+	  debugFunctln("camCallBack() - Entering exposure state");
 	  Engine.state(ST_EXP);
   }
-  else if( code == OM_CAM_EFIN ) {
-	if (usb_debug & DB_FUNCT)
-	  USBSerial.println("camCallBack() - Entering wait state");
+  else if( code == OM_CAM_EFIN ) {	
+	debugFunctln("camCallBack() - Entering wait state");
 	camera_fired++;
     Engine.state(ST_WAIT);
   }

--- a/Firmware/Motion_Engine/OM_ControlCycle.ino
+++ b/Firmware/Motion_Engine/OM_ControlCycle.ino
@@ -50,13 +50,11 @@ void setupControlCycle() {
 
 void cycleCamera() {
 
-	if (usb_debug & DB_FUNCT)
-		USBSerial.println("cycleCamera() - Entering function");
+	debugFunctln("cycleCamera() - Entering function");
 
 	// Check to see if a pause was requested. The program is paused here to avoid unexpected stops in the middle of a move or exposure.
 	if (pause_flag) {
-		if (usb_debug & DB_FUNCT)
-			USBSerial.println("cycleCamera() - Pausing program");
+		debugFunctln("cycleCamera() - Pausing program");
 		pauseProgram();
 	}
 
@@ -91,17 +89,16 @@ void cycleCamera() {
 		  ready_to_stop = false;
 
 		  // Debug output
-		  if (usb_debug & DB_FUNCT) {
-			  USBSerial.println("cycleCamera() - All motors done moving!");
-			  if ((totalProgramTime() - last_run_time) > 0) {
-				  USBSerial.println(totalProgramTime());
-				  USBSerial.println(last_run_time);
-				  USBSerial.print("cycleCamera() - There are ");
-				  USBSerial.print((long)totalProgramTime() - (long)last_run_time);
-				  USBSerial.println("ms of lead-out time remaining");
-			  }
-
+		  debugFunctln("cycleCamera() - All motors done moving!");
+		  if ((totalProgramTime() - last_run_time) > 0) {
+			  debugFunctln(totalProgramTime());
+			  debugFunctln(last_run_time);
+			  debugFunct("cycleCamera() - There are ");
+			  debugFunct((long)totalProgramTime() - (long)last_run_time);
+			  debugFunctln("ms of lead-out time remaining");
 		  }
+
+		
 	  }
 
 		// stop program running w/o clearing variables

--- a/Firmware/Motion_Engine/OM_KeyFrameControl.ino
+++ b/Firmware/Motion_Engine/OM_KeyFrameControl.ino
@@ -578,4 +578,6 @@ int kf_getPercentDone(){
 		ret = ((float)kf_run_time / kf_getMaxMoveTime()) * PERCENT_CONVERT;
 	else
 		ret = ((float)kf_run_time / kf_getMaxCamTime()) * PERCENT_CONVERT;
+
+	return ret;
 }

--- a/Firmware/Motion_Engine/OM_KeyFrameControl.ino
+++ b/Firmware/Motion_Engine/OM_KeyFrameControl.ino
@@ -112,7 +112,7 @@ void kf_startProgram(){
 		// Take up any motor backlash		
 		debugFunctln("Taking up backlash...");
 		takeUpBacklash();			
-				
+		USBSerial.println("Break 10");
 
 		// SMS Moves
 		if (Motors::planType() == SMS){
@@ -130,28 +130,38 @@ void kf_startProgram(){
 		}
 		// Cont TL and Vid moves
 		else{
+			USBSerial.println("Break 11");
 			// Turn on joystick mode
 			joystickSet(true);
-
+			USBSerial.println("Break 12");
 			// Set the initial motor speeds			
 			debugFunctln("Setting initial motor speeds...");
+			USBSerial.println("Break 13");
 			for (byte i = 0; i < MOTOR_COUNT; i++){
+				USBSerial.println("Break 14");
 				// Don't touch motors that don't have any key frames
 				if (kf[i].getKFCount() > 0){
+					USBSerial.println("Break 15");
 					// If the first key frame isn't at x == 0 (i.e. there is a lead-in), set velocity to 0
-					if (kf[i].getXN(0) == 0)
+					if (kf[i].getXN(0) == 0){
+						USBSerial.println("Break 1");
 						setJoystickSpeed(i, kf[i].vel(0) * MILLIS_PER_SECOND);
-					else
+					}
+					else{
+						USBSerial.println("Break 16");
 						setJoystickSpeed(i, 0);
+					}
 				}
 			}
 		}
 
 		// Initialize the run timers		
+		USBSerial.println("Break 17");
 		debugFunctln("Initializing run timers...");
 		kf_run_time = 0;
 		kf_start_time = millis();
 		kf_last_update = millis();		
+		USBSerial.println("Break 18");
 	}
 
 	// Turn on the key frame program flag and turn the paused flag off
@@ -207,6 +217,7 @@ void kf_stopProgram(){
 }
 
 void kf_updateProgram(){
+	USBSerial.println("Break 19");
 
 	// If the program is paused, just keep track of the pause time
 	if (kf_paused){
@@ -236,6 +247,7 @@ void kf_updateProgram(){
 	
 	// Continuous move update	
 	if (Motors::planType() != SMS){
+		USBSerial.println("About to update speed");
 		kf_updateContSpeed();
 	}
 
@@ -247,9 +259,12 @@ void kf_updateProgram(){
 	if (Motors::planType() == SMS){
 		kf_updateSMS();
 	}
-
+	USBSerial.println("Break 20");
 	// Check to see if the program is done
 	if (kf_run_time > kf_getMaxCamTime()){
+		USBSerial.println(kf_run_time);
+		USBSerial.println(kf_getMaxCamTime());
+		USBSerial.println("Program done!");
 		kf_stopProgram();
 	}
 }
@@ -258,16 +273,19 @@ void kf_updateContSpeed(){
 
 	// If the update time has elapsed, update the motor speed
 	if (millis() - kf_last_update > KeyFrames::updateRate()){
-
+		USBSerial.println("Break 21");
 		for (byte i = 0; i < MOTOR_COUNT; i++){
-
+			USBSerial.println("Break 22");
 			// Determine the maximum run time for this axis
 			float thisAxisMaxTime = kf[i].getXN(kf[i].getKFCount() - 1);
+			USBSerial.println("Break 23");
 			if (Motors::planType() == SMS)
+				USBSerial.println("Break 24");
 				thisAxisMaxTime = thisAxisMaxTime * Camera.intervalTime();
 
 			// Set the approriate speed, but don't touch motors that don't have any key frames
 			if (kf[i].getKFCount() > 0){
+				USBSerial.println("Break 25");
 				float speed;
 				if (kf_run_time > thisAxisMaxTime)
 					speed = 0;
@@ -282,6 +300,9 @@ void kf_updateContSpeed(){
 			}
 		}
 		kf_last_update = millis();
+	}
+	else{
+		USBSerial.println("not time to update yet");
 	}
 }
 

--- a/Firmware/Motion_Engine/OM_KeyFrameControl.ino
+++ b/Firmware/Motion_Engine/OM_KeyFrameControl.ino
@@ -71,20 +71,19 @@ void kf_printKeyFrameData(){
 void kf_startProgram(){
 		
 	// If resuming
-	if (kf_paused){
-
-		USBSerial.println("Resuming KF program");
+	if (kf_paused){		
+		debugFunctln("Resuming KF program");
 
 		// Add the time of the last pause to the total pause time counter
 		kf_pause_time += kf_this_pause;
 	}
 	// If starting a new program
 	else{
+				
+		debugFunct("Starting new type ");
+		debugFunct((int)Motors::planType());
+		debugFunctln(" KF program");		
 
-		USBSerial.print("Starting new type ");
-		USBSerial.print(Motors::planType());
-		USBSerial.println(" KF program");
-		
 		// Reset the SMS vars
 		kf_okForSmsMove = false;
 		kf_curSmsFrame = 0;
@@ -110,20 +109,22 @@ void kf_startProgram(){
 		kf_getMaxMoveTime();
 		kf_getMaxCamTime();
 
-		// Take up any motor backlash
-		USBSerial.println("Taking up backlash...");
+		// Take up any motor backlash		
+		debugFunctln("Taking up backlash...");
 		takeUpBacklash();			
 				
 
 		// SMS Moves
 		if (Motors::planType() == SMS){
 			// Convert from "frames" to real milliseconds, based upon the camera interval			
-			USBSerial.print("Camera interval");
-			USBSerial.println(Camera.intervalTime());
-			USBSerial.print("Program move time in milliseconds: ");
-			USBSerial.println(kf_getMaxMoveTime());
-			USBSerial.print("Program cam time in milliseconds: ");
-			USBSerial.println(kf_getMaxCamTime());
+			
+			debugFunct("Camera interval");
+			debugFunctln(Camera.intervalTime());
+			debugFunct("Program move time in milliseconds: ");
+			debugFunctln(kf_getMaxMoveTime());
+			debugFunct("Program cam time in milliseconds: ");
+			debugFunctln(kf_getMaxCamTime());
+			
 			// Make sure joystick mode is off, then set move speed for the motors
 			joystickSet(false);
 		}
@@ -132,8 +133,8 @@ void kf_startProgram(){
 			// Turn on joystick mode
 			joystickSet(true);
 
-			// Set the initial motor speeds
-			USBSerial.println("Setting initial motor speeds...");
+			// Set the initial motor speeds			
+			debugFunctln("Setting initial motor speeds...");
 			for (byte i = 0; i < MOTOR_COUNT; i++){
 				// Don't touch motors that don't have any key frames
 				if (kf[i].getKFCount() > 0){
@@ -146,8 +147,8 @@ void kf_startProgram(){
 			}
 		}
 
-		// Initialize the run timers
-		USBSerial.println("Initializing run timers...");
+		// Initialize the run timers		
+		debugFunctln("Initializing run timers...");
 		kf_run_time = 0;
 		kf_start_time = millis();
 		kf_last_update = millis();		
@@ -164,13 +165,13 @@ void kf_startProgram(){
 
 void kf_pauseProgram(){
 
-	if (usb_debug & DB_FUNCT)
-		USBSerial.print("PAUSING KF PROGRAM");
+	
+	debugFunctln("PAUSING KF PROGRAM");
 
 	// Stop all motors
-	for (byte i = 0; i < MOTOR_COUNT; i++){
-		USBSerial.print("Stopping motor ");
-		USBSerial.println(i);
+	for (int i = 0; i < MOTOR_COUNT; i++){
+		debugFunct("Stopping motor ");
+		debugFunctln(i);
 		setJoystickSpeed(i, 0);
 	}
 
@@ -186,8 +187,7 @@ void kf_pauseProgram(){
 
 void kf_stopProgram(){
 
-	if (usb_debug & DB_FUNCT)
-		USBSerial.print("STOPPING KF PROGRAM");
+	debugFunct("STOPPING KF PROGRAM");
 
 	// Make sure all motors are stopped
 	for (byte i = 0; i < MOTOR_COUNT; i++){
@@ -211,10 +211,10 @@ void kf_updateProgram(){
 	// If the program is paused, just keep track of the pause time
 	if (kf_paused){
 		kf_this_pause = millis() - kf_pause_start;
-		if (usb_debug & DB_FUNCT){
-			USBSerial.print("Pause length: ");
-			USBSerial.println(kf_this_pause);
-		}
+		
+		debugFunct("Pause length: ");
+		debugFunctln(kf_this_pause);
+		
 		return;
 	}
 
@@ -293,7 +293,8 @@ void kf_updateSMS(){
 	}
 
 	// Send the motors to their next locations
-	USBSerial.println("Sending motors to new locations");
+	
+	debugFunctln("Sending motors to new locations");
 	for (int i = 0; i < MOTOR_COUNT; i++){		
 
 		// Make sure there is a point to actually query
@@ -301,12 +302,13 @@ void kf_updateSMS(){
 			continue;
 
 		float nextPos = kf[i].pos(kf_curSmsFrame + 1);
+				
+		debugFunct("About to send to location #: ");
+		debugFunctln(kf_curSmsFrame + 1);
+		debugFunct("Sending to ");
+		debugFunctln(nextPos);
+		debugFunctln("");
 		
-		USBSerial.print("About to send to location #: ");
-		USBSerial.println(kf_curSmsFrame + 1);		
-		USBSerial.print("Sending to ");
-		USBSerial.println(nextPos);		
-		USBSerial.println("");
 		sendTo(i, (long)nextPos);		
 		
 	}		
@@ -357,8 +359,7 @@ void kf_CameraCheck() {
 		if (!kf_auxFired){
 			altBlock = ALT_OUT_BEFORE;
 			altOutStart(ALT_OUT_BEFORE);
-			if (usb_debug & DB_FUNCT)
-				USBSerial.println("cycleCamera() - Bailing from camera cycle at point 2");
+			debugFunctln("cycleCamera() - Bailing from camera cycle at point 2");
 			kf_auxFired = true;
 			return;
 		}
@@ -375,9 +376,9 @@ void kf_CameraCheck() {
 		
 	// Trigger the focus
 	if (!kf_focusDone){
-		if (!kf_focusFired){
-			USBSerial.print("Time at focus: ");
-			USBSerial.println(kf_run_time);
+		if (!kf_focusFired){			
+			debugFunct("Time at focus: ");
+			debugFunctln(kf_run_time);			
 			Camera.focus();
 			kf_focusFired = true;
 			return;
@@ -392,9 +393,9 @@ void kf_CameraCheck() {
 	
 	// Trigger the exposure
 	if (!kf_shutterDone){
-		if (!kf_shutterFired){
-			USBSerial.print("Time at exposure: ");
-			USBSerial.println(kf_run_time);		
+		if (!kf_shutterFired){			
+			debugFunct("Time at exposure: ");
+			debugFunctln(kf_run_time);			
 			Camera.expose();
 			kf_shutterFired = true;
 		}
@@ -406,8 +407,8 @@ void kf_CameraCheck() {
 		kf_shutterDone = true;
 		kf_forceShotInProgress = false;
 
-		// One the camera functions are complete, it's okay to make the next SMS move
-		USBSerial.println("Shutter done, ready for move");
+		// One the camera functions are complete, it's okay to make the next SMS move		
+		debugFunctln("Shutter done, ready for move");
 		kf_okForSmsMove = true;
 	}
 
@@ -513,15 +514,16 @@ long kf_getMaxMoveTime(){
 		// SMS and cont. TL mode 
 		if (Motors::planType() != CONT_VID){			
 			move_time = Camera.getMaxShots() * Camera.intervalTime();
-			USBSerial.print("Getting TL move time: ");			
+			debugFunct("Getting TL move time: ");
 		}
 		// Continuous video mode
 		else{			
-			move_time = KeyFrames::getContVidTime();			
-			USBSerial.print("Getting video move time: ");			
+			move_time = KeyFrames::getContVidTime();						
+			debugFunct("Getting video move time: ");
+			
 		}
-		USBSerial.print(move_time);
-		USBSerial.println("ms");
+		debugFunct(move_time);		
+		debugFunctln("ms");
 	}
 
 	return move_time;

--- a/Firmware/Motion_Engine/OM_KeyFrameControl.ino
+++ b/Firmware/Motion_Engine/OM_KeyFrameControl.ino
@@ -107,12 +107,7 @@ void kf_startProgram(){
 				
 		// Prep the movement and camera times
 		kf_getMaxMoveTime();
-		kf_getMaxCamTime();
-
-		// Take up any motor backlash		
-		debugFunctln("Taking up backlash...");
-		takeUpBacklash();			
-		USBSerial.println("Break 10");
+		kf_getMaxCamTime();				
 
 		// SMS Moves
 		if (Motors::planType() == SMS){
@@ -129,39 +124,30 @@ void kf_startProgram(){
 			joystickSet(false);
 		}
 		// Cont TL and Vid moves
-		else{
-			USBSerial.println("Break 11");
+		else{			
 			// Turn on joystick mode
-			joystickSet(true);
-			USBSerial.println("Break 12");
+			joystickSet(true);			
 			// Set the initial motor speeds			
-			debugFunctln("Setting initial motor speeds...");
-			USBSerial.println("Break 13");
-			for (byte i = 0; i < MOTOR_COUNT; i++){
-				USBSerial.println("Break 14");
+			debugFunctln("Setting initial motor speeds...");			
+			for (byte i = 0; i < MOTOR_COUNT; i++){				
 				// Don't touch motors that don't have any key frames
-				if (kf[i].getKFCount() > 0){
-					USBSerial.println("Break 15");
+				if (kf[i].getKFCount() > 0){					
 					// If the first key frame isn't at x == 0 (i.e. there is a lead-in), set velocity to 0
 					if (kf[i].getXN(0) == 0){
-						USBSerial.println("Break 1");
 						setJoystickSpeed(i, kf[i].vel(0) * MILLIS_PER_SECOND);
 					}
 					else{
-						USBSerial.println("Break 16");
 						setJoystickSpeed(i, 0);
 					}
 				}
 			}
 		}
 
-		// Initialize the run timers		
-		USBSerial.println("Break 17");
+		// Initialize the run timers				
 		debugFunctln("Initializing run timers...");
 		kf_run_time = 0;
 		kf_start_time = millis();
 		kf_last_update = millis();		
-		USBSerial.println("Break 18");
 	}
 
 	// Turn on the key frame program flag and turn the paused flag off
@@ -217,7 +203,6 @@ void kf_stopProgram(){
 }
 
 void kf_updateProgram(){
-	USBSerial.println("Break 19");
 
 	// If the program is paused, just keep track of the pause time
 	if (kf_paused){
@@ -231,11 +216,10 @@ void kf_updateProgram(){
 
 	// Update run_time, don't include time spent paused
 	kf_run_time = millis() - kf_start_time - kf_pause_time;
-
-	if (usb_debug & DB_FUNCT){
-		USBSerial.print("Run time: ");
-		USBSerial.println(kf_run_time);
-	}
+		
+	debugFunct("Run time: ");
+	debugFunctln(kf_run_time);
+	
 
 	// Adding a small delay seems to keep the controller from randomly locking. I don't know why...
 	int time_delay = 500;
@@ -246,8 +230,7 @@ void kf_updateProgram(){
 
 	
 	// Continuous move update	
-	if (Motors::planType() != SMS){
-		USBSerial.println("About to update speed");
+	if (Motors::planType() != SMS){		
 		kf_updateContSpeed();
 	}
 
@@ -259,12 +242,9 @@ void kf_updateProgram(){
 	if (Motors::planType() == SMS){
 		kf_updateSMS();
 	}
-	USBSerial.println("Break 20");
+
 	// Check to see if the program is done
 	if (kf_run_time > kf_getMaxCamTime()){
-		USBSerial.println(kf_run_time);
-		USBSerial.println(kf_getMaxCamTime());
-		USBSerial.println("Program done!");
 		kf_stopProgram();
 	}
 }
@@ -273,19 +253,14 @@ void kf_updateContSpeed(){
 
 	// If the update time has elapsed, update the motor speed
 	if (millis() - kf_last_update > KeyFrames::updateRate()){
-		USBSerial.println("Break 21");
 		for (byte i = 0; i < MOTOR_COUNT; i++){
-			USBSerial.println("Break 22");
 			// Determine the maximum run time for this axis
 			float thisAxisMaxTime = kf[i].getXN(kf[i].getKFCount() - 1);
-			USBSerial.println("Break 23");
 			if (Motors::planType() == SMS)
-				USBSerial.println("Break 24");
 				thisAxisMaxTime = thisAxisMaxTime * Camera.intervalTime();
 
 			// Set the approriate speed, but don't touch motors that don't have any key frames
 			if (kf[i].getKFCount() > 0){
-				USBSerial.println("Break 25");
 				float speed;
 				if (kf_run_time > thisAxisMaxTime)
 					speed = 0;
@@ -300,9 +275,6 @@ void kf_updateContSpeed(){
 			}
 		}
 		kf_last_update = millis();
-	}
-	else{
-		USBSerial.println("not time to update yet");
 	}
 }
 

--- a/Firmware/Motion_Engine/OM_Motor_Control.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Control.ino
@@ -147,6 +147,10 @@ byte motorSleep(byte p_motor) {
 
 */
 void takeUpBacklash(){
+	takeUpBacklash(false);
+}
+
+void takeUpBacklash(boolean kf_move){
 	USBSerial.println("Taking up backlash");
 	uint8_t wait_required = false;
 	USBSerial.println("Break 1");
@@ -177,13 +181,18 @@ void takeUpBacklash(){
 		}
 	}
 
-	if (wait_required) {
-		unsigned long time = millis();
-		while (millis() - time < MILLIS_PER_SECOND){
-			// Wait a second for backlash takeup to finish
-		}
+	// Can't wait when it's a keyframe move. For some reason this causes the controller to lock	
+	unsigned long time = millis();
+	while (wait_required && !kf_move){
+		// Wait a second for backlash takeup to finish
+		USBSerial.print("Time elapsed: ");
+		USBSerial.println(millis() - time);
+		if (millis() - time > MILLIS_PER_SECOND){
+			USBSerial.println("Done waiting!");
+			break;
+		}	
 	}
-
+	USBSerial.println("Out of loop and moving on!");
 	// Re-set all the motors to their proper microstep settings
 	for (byte i = 0; i < MOTOR_COUNT; i++) {
 		/*if (!graffikMode())

--- a/Firmware/Motion_Engine/OM_Motor_Control.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Control.ino
@@ -158,8 +158,8 @@ void takeUpBacklash(){
 			wait_required = true;
 
 			// Set the motor microsteps to low resolution and increase speed for fastest takeup possible
-			if (!graffikMode())
-				motor[i].ms(4);
+			/*if (!graffikMode())
+				motor[i].ms(4);*/
 			motor[i].contSpeed(mot_max_speed);
 
 			// Determine the direction of the programmed move
@@ -180,8 +180,8 @@ void takeUpBacklash(){
 
 	// Re-set all the motors to their proper microstep settings
 	for (byte i = 0; i < MOTOR_COUNT; i++) {
-		if (!graffikMode())
-			msAutoSet(i);
+		/*if (!graffikMode())
+			msAutoSet(i);*/
 
 		// Print debug info if proper flag is set
 		if (usb_debug & DB_FUNCT){
@@ -410,7 +410,7 @@ p_motor_number: motor to modify microstepping
 */
 
 byte msAutoSet(uint8_t p_motor) {
-
+	USBSerial.println("Trying to auto-set microsteps!!!!");
 	unsigned long time = millis();
 	byte microsteps;
 	

--- a/Firmware/Motion_Engine/OM_Motor_Control.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Control.ino
@@ -247,28 +247,28 @@ void startProgramCom() {
 	// Don't start a new program if one is already running
 	if (!running) {
 
-		if (usb_debug & DB_FUNCT){
-			USBSerial.println("Motor distances:");
-			for (byte i = 0; i < MOTOR_COUNT; i++){
-				USBSerial.println(motor[i].stopPos() - motor[i].currentPos());
-			}
-			USBSerial.println("Motor start:");
-			for (byte i = 0; i < MOTOR_COUNT; i++){
-				USBSerial.println(motor[i].startPos());
-			}
-			USBSerial.println("Motor stop:");
-			for (byte i = 0; i < MOTOR_COUNT; i++){
-				USBSerial.println(motor[i].stopPos());
-			}
-			USBSerial.println("Motor current:");
-			for (byte i = 0; i < MOTOR_COUNT; i++){
-				USBSerial.println(motor[i].currentPos());
-			}
-			USBSerial.println("Motor travel:");
-			for (byte i = 0; i < MOTOR_COUNT; i++){
-				USBSerial.println(motor[i].planTravelLength());
-			}
+		
+		debugFunctln("Motor distances:");
+		for (byte i = 0; i < MOTOR_COUNT; i++){
+			debugFunctln(motor[i].stopPos() - motor[i].currentPos());
 		}
+		debugFunctln("Motor start:");
+		for (byte i = 0; i < MOTOR_COUNT; i++){
+			debugFunctln(motor[i].startPos());
+		}
+		debugFunctln("Motor stop:");
+		for (byte i = 0; i < MOTOR_COUNT; i++){
+			debugFunctln(motor[i].stopPos());
+		}
+		debugFunctln("Motor current:");
+		for (byte i = 0; i < MOTOR_COUNT; i++){
+			debugFunctln(motor[i].currentPos());
+		}
+		debugFunctln("Motor travel:");
+		for (byte i = 0; i < MOTOR_COUNT; i++){
+			debugFunctln(motor[i].planTravelLength());
+		}
+		
 
 		//if it was paused and not SMS then recalculate move from pause time
 		if (was_pause && Motors::planType() != SMS){
@@ -371,17 +371,15 @@ byte validateProgram(byte p_motor, bool p_autosteps) {
 		comparison_speed = motor[p_motor].getTopSpeed();
 	}
 
-	// USB print the debug value, if necessary
-	if (usb_debug & DB_FUNCT){
-		USBSerial.print("Top speed requested: ");
-		USBSerial.println(comparison_speed);
-	}
+	// USB print the debug value, if necessary	
+	debugFunct("Top speed requested: ");
+	debugFunctln(comparison_speed);
 
 	// Check the comparison speed against the cutoff values and select the appropriate microstepping setting
 	// If the requested speed is too high, send error value, don't change microstepping setting
 	if (comparison_speed >= MAX_CUTOFF ) {
-		if (usb_debug & DB_FUNCT)
-			USBSerial.println("Excessive speed requested");
+		
+		debugFunctln("Excessive speed requested");
 		return 0;
 	}
 	else {
@@ -410,7 +408,7 @@ p_motor_number: motor to modify microstepping
 */
 
 byte msAutoSet(uint8_t p_motor) {
-	USBSerial.println("Trying to auto-set microsteps!!!!");
+	debugFunctln("Trying to auto-set microsteps!!!!");
 	unsigned long time = millis();
 	byte microsteps;
 	
@@ -431,21 +429,19 @@ byte msAutoSet(uint8_t p_motor) {
 		// Save the microstep settings
 		OMEEPROM::write(EE_MS_0 + (p_motor * EE_MOTOR_MEMORY_SPACE), microsteps);
 
-		// USB print the debug value, if necessary
-		if (usb_debug & DB_FUNCT){
-			USBSerial.print("Requested Microsteps: ");
-			USBSerial.println(microsteps);
-			USBSerial.println("Microsteps successfully set");
-		}
+		// USB print the debug value, if necessary		
+		debugFunct("Requested Microsteps: ");
+		debugFunctln((int)microsteps);
+		debugFunctln("Microsteps successfully set");
+		
 		return microsteps;
 		
 	}	
 
 	// If the motor or program is running and a report is requested, return 0 to indicate that the auto-set routine was not completed
-	else {
-		if (usb_debug & DB_FUNCT)
-				USBSerial.println("Motors are running, can't auto-set microsteps");
-			return false;
+	else {		
+		debugFunctln("Motors are running, can't auto-set microsteps");
+		return false;
 	}
 }
 

--- a/Firmware/Motion_Engine/OM_Motor_Control.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Control.ino
@@ -147,27 +147,33 @@ byte motorSleep(byte p_motor) {
 
 */
 void takeUpBacklash(){
-
+	USBSerial.println("Taking up backlash");
 	uint8_t wait_required = false;
-
+	USBSerial.println("Break 1");
 	// Check each motor to see if it needs backlash compensation
 	for (byte i = 0; i < MOTOR_COUNT; i++) {
+		USBSerial.println("Break 2");
 		if (motor[i].programBackCheck() == true && motor[i].backlash() > 0) {
-
+			USBSerial.println("Break 3");
 			// Indicate that a brief pause is necessary after starting the motors
 			wait_required = true;
+			USBSerial.println("Break 4");
 
 			// Set the motor microsteps to low resolution and increase speed for fastest takeup possible
 			/*if (!graffikMode())
 				motor[i].ms(4);*/
+			USBSerial.println("Break 5");
 			motor[i].contSpeed(mot_max_speed);
 
+			USBSerial.println("Break 6");
 			// Determine the direction of the programmed move
 			uint8_t dir = (motor[i].stopPos() - motor[i].startPos()) > 0 ? 1 : 0;
-
+			USBSerial.println("Break 7");
 			// Move the motor 1 step in that direction to force the backlash takeup
 			motor[i].move(dir, 1);
+			USBSerial.println("Break 8");
 			startISR();
+			USBSerial.println("Break 9");
 		}
 	}
 

--- a/Firmware/Motion_Engine/OM_Motor_Travel.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Travel.ino
@@ -60,9 +60,9 @@ void sendToStart(uint8_t p_motor) {
 	else
 		motor[p_motor].programBackCheck(false);
 
-	// Move at the maximum motor speed
-	if (!graffikMode())
-		motor[p_motor].ms(4);
+	//// Move at the maximum motor speed
+	//if (!graffikMode())
+	//	motor[p_motor].ms(4);
 	motor[p_motor].contSpeed(mot_max_speed);
 
 	// Start the move
@@ -72,9 +72,9 @@ void sendToStart(uint8_t p_motor) {
 
 void sendToStop(uint8_t p_motor){
 
-	// Move at the maximum motor speed
-	if (!graffikMode())
-		motor[p_motor].ms(4);
+	//// Move at the maximum motor speed
+	//if (!graffikMode())
+	//	motor[p_motor].ms(4);
 	motor[p_motor].contSpeed(mot_max_speed);
 
 	motor[p_motor].moveToStop();
@@ -83,10 +83,10 @@ void sendToStop(uint8_t p_motor){
 
 void sendTo(uint8_t p_motor, long p_pos){
 	
-	// When not in Graffik Mode (i.e. App mode), use the lowest microsteps
-	if (!graffikMode()){
-		motor[p_motor].ms(4);		
-	}
+	//// When not in Graffik Mode (i.e. App mode), use the lowest microsteps
+	//if (!graffikMode()){
+	//	motor[p_motor].ms(4);		
+	//}
 
 	// Move at the maximum motor speed
 	motor[p_motor].contSpeed(mot_max_speed);

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -965,8 +965,8 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 	//Command 11 send motor to home limit
 	case 11:
 		// Move at the maximum motor speed
-		if (!graffikMode())
-			motor[subaddr - 1].ms(4);
+		/*if (!graffikMode())
+			motor[subaddr - 1].ms(4);*/
 		motor[subaddr - 1].contSpeed(mot_max_speed);
 
 		// send a motor home
@@ -978,8 +978,8 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 	//Command 12 send motor to end limit
 	case 12:
 		// Move at the maximum motor speed
-		if (!graffikMode())
-			motor[subaddr - 1].ms(4);
+		//if (!graffikMode())
+		//	motor[subaddr - 1].ms(4);
 		motor[subaddr - 1].contSpeed(mot_max_speed);
 
 		motor[subaddr - 1].moveToEnd();
@@ -1683,11 +1683,17 @@ void serKeyFrame(byte command, byte* input_serial_buffer){
 		int axis = KeyFrames::getAxis();
 				
 		// Set the start and stop positions from first and last key points			
-		int start = kf[axis].getFN(0);
-		motor[axis].startPos(start);
+		if (kf[axis].getKFCount() > 1){
+			long start = kf[axis].getFN(0);
+			motor[axis].startPos(start);
 
-		int stop = kf[axis].getFN(kf[axis].getKFCount() - 1);
-		motor[axis].stopPos(stop);
+			long stop = kf[axis].getFN(kf[axis].getKFCount() - 1);
+			motor[axis].stopPos(stop);
+		}
+		else{
+			motor[axis].startPos(motor[axis].currentPos());
+			motor[axis].stopPos(motor[axis].currentPos());
+		}
 
 		if (usb_debug & DB_GEN_SER){
 			USBSerial.print("Axis ");

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -917,9 +917,13 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 
 	//Command 5 set motor's backlash amount  
 	case 5:
-		motor[subaddr - 1].backlash(Node.ntoui(input_serial_buffer));
+	{
+		USBSerial.println("Backlash from serial");
+		unsigned int in_val = Node.ntoui(input_serial_buffer);		
+		motor[subaddr - 1].backlash(in_val);
 		response(true);
 		break;
+	}
     
 	//Command 6 set the microstep for the motor
 	case 6:

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -1734,7 +1734,7 @@ void serKeyFrame(byte command, byte* input_serial_buffer){
 
 	// Command 20 runs/resumes a keyframe program
 	case 20:
-	{	   
+	{	  			
 		kf_startProgram();	   
 		response(true);
 		break;
@@ -1750,6 +1750,13 @@ void serKeyFrame(byte command, byte* input_serial_buffer){
 	case 22:
 		kf_stopProgram();
 		response(true);
+		break;
+
+	// Command 23 causes the motor backlash to be taken up
+	case 23:
+		// Take up any motor backlash		
+		debugFunctln("Taking up backlash...");
+		takeUpBacklash();
 		break;
 
 

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -1176,7 +1176,7 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 	//Command 31 sends the motor to the specified position
 	case 31:
 	{
-		long pos = Node.ntoul(input_serial_buffer);
+		long pos = Node.ntol(input_serial_buffer);
 		sendTo(subaddr - 1, pos);
 		response(true);
 		break;


### PR DESCRIPTION
Backlash is not taken up automatically during KF programs. It must be taken up via an explicit serial command in order to avoid locking the controller.