### PR TITLE
"Send to" speed, backlash, start delay

### DIFF
--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -95,8 +95,16 @@ const int EE_STOP_2  = EE_START_2 + 4;		// Motor 2 program stop position (long i
 const int EE_MS_2    = EE_STOP_2  + 4;		// Motor 2 microstep value (byte)
 const int EE_SLEEP_2 = EE_MS_2    + 1;		// Motor 0 sleep state (byte)
 
+const int EE_LOAD_POS		 = EE_SLEEP_2 + 1;			// Whether to load the motors' current positions after power cycle (byte)
+const int EE_LOAD_START_STOP = EE_LOAD_POS + 1;			// Whether to load the motors' start/stop positions after power cycle (byte)
+const int EE_LOAD_END		 = EE_LOAD_START_STOP + 1;	// Whether to load the motors' end positions after power cycle (byte)
+
 const int EE_MOTOR_MEMORY_SPACE = 18;		//Number of bytes required for storage for each motor's variables
 
+// Variables that are loaded from EEPROM that determine whether the motors' various positions should be restored
+uint8_t ee_load_curPos = false;
+uint8_t ee_load_endPos = false;
+uint8_t ee_load_startStop = false;
 
 /***************************************
 
@@ -229,6 +237,9 @@ unsigned int mot_max_speed = MOT_DEFAULT_MAX_SPD;			// Maximum motor speed in st
 uint8_t ISR_On = false;
 char byteFired = 0;				// Byte used to toggle the step pin for each motor within the ISR
 
+// This is used because setting the end position in the motor library causes the NMX communications to lock up.
+// That really ought to be looked into...
+long endPos[] = { 0, 0, 0 };
 
 /***************************************
 

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -115,7 +115,7 @@ byte node							= MOCOBUS;			// default node to use (MoCo Serial = 1; AltSoftSer
 byte device_name[]					= "DEFAULT   ";		// default device name, exactly 9 characters + null terminator
 int device_address					= 3;				// NMX address (default = 3)
 const byte START_FLASH_CNT			= 5;				// # of flashes of debug led at startup
-const byte FLASH_DELAY				= 250;				// Time between flashes in milliseconds
+const byte FLASH_DELAY				= 100;				// Time between flashes in milliseconds
 const unsigned int START_RST_TM		= 5000;				// # of milliseconds PBT must be held low to do a factory reset
 uint8_t debug_led_enable			= false;			// Debug led state
 uint8_t timing_master				= true;				// Do we generate timing for all devices on the network? i.e. -are we the timing master?
@@ -896,9 +896,9 @@ void flasher(byte pin, int count) {
     
    for(int i = 0; i < count; i++) {
       digitalWrite(pin, HIGH);
-      delay(250);
+	  delay(FLASH_DELAY);
       digitalWrite(pin, LOW);
-      delay(250); 
+	  delay(FLASH_DELAY);
    }
    
 }

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -317,6 +317,7 @@ unsigned long kf_pause_start;
 unsigned long kf_this_pause;
 unsigned long kf_pause_time;
 unsigned long kf_last_shot_tm;
+boolean kf_just_started = true;
 boolean kf_running = false;
 boolean kf_paused = false;
 

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -584,6 +584,13 @@ void loop() {
 	   kf_updateProgram();	   
    }
 
+   // Check if any motors are being sent and restore their old microstep settings when they stop
+   for (int i = 0; i < MOTOR_COUNT; i++){
+	   if (motor[i].isSending() && !motor[i].running()){
+		   motor[i].setSending(false);
+		   motor[i].restoreLastMs();
+	   }
+   }
 }
 
 /*

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -95,11 +95,8 @@ const int EE_STOP_2  = EE_START_2 + 4;		// Motor 2 program stop position (long i
 const int EE_MS_2    = EE_STOP_2  + 4;		// Motor 2 microstep value (byte)
 const int EE_SLEEP_2 = EE_MS_2    + 1;		// Motor 0 sleep state (byte)
 
-const int EE_LOAD_POS		 = EE_SLEEP_2 + 1;			// Whether to load the motors' current positions after power cycle (byte)
-const int EE_LOAD_START_STOP = EE_LOAD_POS + 1;			// Whether to load the motors' start/stop positions after power cycle (byte)
-const int EE_LOAD_END		 = EE_LOAD_START_STOP + 1;	// Whether to load the motors' end positions after power cycle (byte)
-
 const int EE_MOTOR_MEMORY_SPACE = 18;		//Number of bytes required for storage for each motor's variables
+
 
 /***************************************
 

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -95,8 +95,11 @@ const int EE_STOP_2  = EE_START_2 + 4;		// Motor 2 program stop position (long i
 const int EE_MS_2    = EE_STOP_2  + 4;		// Motor 2 microstep value (byte)
 const int EE_SLEEP_2 = EE_MS_2    + 1;		// Motor 0 sleep state (byte)
 
-const int EE_MOTOR_MEMORY_SPACE = 18;		//Number of bytes required for storage for each motor's variables
+const int EE_LOAD_POS		 = EE_SLEEP_2 + 1;			// Whether to load the motors' current positions after power cycle (byte)
+const int EE_LOAD_START_STOP = EE_LOAD_POS + 1;			// Whether to load the motors' start/stop positions after power cycle (byte)
+const int EE_LOAD_END		 = EE_LOAD_START_STOP + 1;	// Whether to load the motors' end positions after power cycle (byte)
 
+const int EE_MOTOR_MEMORY_SPACE = 18;		//Number of bytes required for storage for each motor's variables
 
 /***************************************
 

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -110,7 +110,7 @@ const int EE_MOTOR_MEMORY_SPACE = 18;		//Number of bytes required for storage fo
 #define USB 3
 
 const char SERIAL_TYPE[]			= "OMAXISVX";		// Serial API name
-const int SERIAL_VERSION			= 57;				// Serial API version
+const int SERIAL_VERSION			= 58;				// Serial API version
 byte node							= MOCOBUS;			// default node to use (MoCo Serial = 1; AltSoftSerial (BLE) = 2; USBSerial = 3)
 byte device_name[]					= "DEFAULT   ";		// default device name, exactly 9 characters + null terminator
 int device_address					= 3;				// NMX address (default = 3)

--- a/Firmware/Motion_Engine/Motion_Engine.ino
+++ b/Firmware/Motion_Engine/Motion_Engine.ino
@@ -864,10 +864,11 @@ unsigned long totalProgramTime() {
 			// Overwrite longest_time if the last checked motor is longer
 			if (motor_time > longest_time)
 				longest_time = motor_time;
-			// Add the program delay
-			longest_time += start_delay;
 		}
 	}
+
+	// Add the program delay
+	longest_time += start_delay;
 
 	return(longest_time);
 }

--- a/Firmware/Motion_Engine/OM_EEPROM.ino
+++ b/Firmware/Motion_Engine/OM_EEPROM.ino
@@ -40,10 +40,8 @@ See dynamicperception.com for more information
 // EEPROM Memory Layout Version, change this any time you modify what is stored
 const unsigned int MEMORY_VERSION = 4;
 
-// Variables that are loaded from EEPROM that determine whether the motors' various positions should be restored
-uint8_t ee_load_curPos		= false;
-uint8_t ee_load_endPos		= false;
-uint8_t ee_load_startStop	= false;
+
+
 
 /** Check EEPROM Status
 
@@ -80,32 +78,19 @@ void eepromWrite() {
   
   write(EE_ADDR, device_address);
   write(EE_NAME, *device_name, 10);
-  write(EE_LOAD_POS, ee_load_curPos);
-  write(EE_LOAD_START_STOP, ee_load_startStop);
-  write(EE_LOAD_END, ee_load_endPos);
 
 	byte tempMS = 0;
 	bool tempSleep = false;
-	long tempPos = 0;
-	long tempStart = 0;
-	long tempStop = 0;
-	long tempEnd = 0;
-
+	
 	for (int i = 0; i < MOTOR_COUNT; i++){
-		tempMS		= motor[i].ms();
-		tempSleep	= motor[i].sleep();
-		tempPos		= motor[i].currentPos();
-		tempStart	= motor[i].startPos();
-		tempStop	= motor[i].stopPos();
-		tempEnd		= motor[i].endPos();
+		tempMS    = motor[i].ms();
+		tempSleep = motor[i].sleep();
 		
-		write(EE_MS_0		+ EE_MOTOR_MEMORY_SPACE * i, tempMS);
-		write(EE_SLEEP_0	+ EE_MOTOR_MEMORY_SPACE * i, tempSleep);
-		write(EE_POS_0		+ EE_MOTOR_MEMORY_SPACE * i, tempPos);
-		write(EE_START_0	+ EE_MOTOR_MEMORY_SPACE * i, tempStart);
-		write(EE_STOP_0		+ EE_MOTOR_MEMORY_SPACE * i, tempStop);
-		write(EE_END_0		+ EE_MOTOR_MEMORY_SPACE * i, tempEnd);		
-	} 
+		write(EE_MS_0    + EE_MOTOR_MEMORY_SPACE * i, tempMS);
+		write(EE_SLEEP_0 + EE_MOTOR_MEMORY_SPACE * i, tempSleep);
+		
+	}
+ 
 }
 
 
@@ -116,43 +101,25 @@ void eepromRestore() {
   
 	read(EE_ADDR, device_address);
 	read(EE_NAME, *device_name, 10);
-	read(EE_LOAD_POS, ee_load_curPos);
-	read(EE_LOAD_START_STOP, ee_load_startStop);
-	read(EE_LOAD_END, ee_load_endPos);
 	
 	// There had been problems with reading the EEPROM values inside the motor setting functions,
 	// so as a work around, they are saved into these temporary variables which are then used to load
 	// the proper motor settings.
 	
-	byte tempMS		= 0;
-	bool tempSleep	= false;
-	long tempPos = 0;
-	long tempStart	= 0;
-	long tempStop	= 0;
-	long tempEnd	= 0;
+	byte tempMS = 0;
+	bool tempSleep = false;
 	
 	
 	for (int i = 0; i < MOTOR_COUNT; i++){
 
 		read(EE_MS_0    + EE_MOTOR_MEMORY_SPACE * i, tempMS);
 		read(EE_SLEEP_0 + EE_MOTOR_MEMORY_SPACE * i, tempSleep);
-		read(EE_POS_0	+ EE_MOTOR_MEMORY_SPACE * i, tempPos);
-		read(EE_START_0 + EE_MOTOR_MEMORY_SPACE * i, tempStart);
-		read(EE_STOP_0	+ EE_MOTOR_MEMORY_SPACE * i, tempStop);
-		read(EE_END_0	+ EE_MOTOR_MEMORY_SPACE * i, tempEnd);
 		
 		motor[i].ms(tempMS);
-		motor[i].sleep(tempSleep);
-		if (ee_load_curPos)
-			motor[i].currentPos(tempPos);
-		if (ee_load_startStop){
-			motor[i].startPos(tempStart);
-			motor[i].stopPos(tempStop);
-		}
-		if (ee_load_endPos){
-			endPos[i] = tempEnd;
-		}	
+		motor[i].sleep(tempSleep);		
+			
 	}
+
 }
 
 

--- a/Firmware/Motion_Engine/OM_EEPROM.ino
+++ b/Firmware/Motion_Engine/OM_EEPROM.ino
@@ -40,8 +40,10 @@ See dynamicperception.com for more information
 // EEPROM Memory Layout Version, change this any time you modify what is stored
 const unsigned int MEMORY_VERSION = 4;
 
-
-
+// Variables that are loaded from EEPROM that determine whether the motors' various positions should be restored
+uint8_t ee_load_curPos		= false;
+uint8_t ee_load_endPos		= false;
+uint8_t ee_load_startStop	= false;
 
 /** Check EEPROM Status
 
@@ -78,19 +80,32 @@ void eepromWrite() {
   
   write(EE_ADDR, device_address);
   write(EE_NAME, *device_name, 10);
+  write(EE_LOAD_POS, ee_load_curPos);
+  write(EE_LOAD_START_STOP, ee_load_startStop);
+  write(EE_LOAD_END, ee_load_endPos);
 
 	byte tempMS = 0;
 	bool tempSleep = false;
-	
+	long tempPos = 0;
+	long tempStart = 0;
+	long tempStop = 0;
+	long tempEnd = 0;
+
 	for (int i = 0; i < MOTOR_COUNT; i++){
-		tempMS    = motor[i].ms();
-		tempSleep = motor[i].sleep();
+		tempMS		= motor[i].ms();
+		tempSleep	= motor[i].sleep();
+		tempPos		= motor[i].currentPos();
+		tempStart	= motor[i].startPos();
+		tempStop	= motor[i].stopPos();
+		tempEnd		= motor[i].endPos();
 		
-		write(EE_MS_0    + EE_MOTOR_MEMORY_SPACE * i, tempMS);
-		write(EE_SLEEP_0 + EE_MOTOR_MEMORY_SPACE * i, tempSleep);
-		
-	}
- 
+		write(EE_MS_0		+ EE_MOTOR_MEMORY_SPACE * i, tempMS);
+		write(EE_SLEEP_0	+ EE_MOTOR_MEMORY_SPACE * i, tempSleep);
+		write(EE_POS_0		+ EE_MOTOR_MEMORY_SPACE * i, tempPos);
+		write(EE_START_0	+ EE_MOTOR_MEMORY_SPACE * i, tempStart);
+		write(EE_STOP_0		+ EE_MOTOR_MEMORY_SPACE * i, tempStop);
+		write(EE_END_0		+ EE_MOTOR_MEMORY_SPACE * i, tempEnd);		
+	} 
 }
 
 
@@ -101,25 +116,43 @@ void eepromRestore() {
   
 	read(EE_ADDR, device_address);
 	read(EE_NAME, *device_name, 10);
+	read(EE_LOAD_POS, ee_load_curPos);
+	read(EE_LOAD_START_STOP, ee_load_startStop);
+	read(EE_LOAD_END, ee_load_endPos);
 	
 	// There had been problems with reading the EEPROM values inside the motor setting functions,
 	// so as a work around, they are saved into these temporary variables which are then used to load
 	// the proper motor settings.
 	
-	byte tempMS = 0;
-	bool tempSleep = false;
+	byte tempMS		= 0;
+	bool tempSleep	= false;
+	long tempPos = 0;
+	long tempStart	= 0;
+	long tempStop	= 0;
+	long tempEnd	= 0;
 	
 	
 	for (int i = 0; i < MOTOR_COUNT; i++){
 
 		read(EE_MS_0    + EE_MOTOR_MEMORY_SPACE * i, tempMS);
 		read(EE_SLEEP_0 + EE_MOTOR_MEMORY_SPACE * i, tempSleep);
+		read(EE_POS_0	+ EE_MOTOR_MEMORY_SPACE * i, tempPos);
+		read(EE_START_0 + EE_MOTOR_MEMORY_SPACE * i, tempStart);
+		read(EE_STOP_0	+ EE_MOTOR_MEMORY_SPACE * i, tempStop);
+		read(EE_END_0	+ EE_MOTOR_MEMORY_SPACE * i, tempEnd);
 		
 		motor[i].ms(tempMS);
-		motor[i].sleep(tempSleep);		
-			
+		motor[i].sleep(tempSleep);
+		if (ee_load_curPos)
+			motor[i].currentPos(tempPos);
+		if (ee_load_startStop){
+			motor[i].startPos(tempStart);
+			motor[i].stopPos(tempStop);
+		}
+		if (ee_load_endPos){
+			endPos[i] = tempEnd;
+		}	
 	}
-
 }
 
 

--- a/Firmware/Motion_Engine/OM_EEPROM.ino
+++ b/Firmware/Motion_Engine/OM_EEPROM.ino
@@ -42,7 +42,6 @@ const unsigned int MEMORY_VERSION = 4;
 
 
 
-
 /** Check EEPROM Status
 
  If EEPROM hasn't been stored, or EEPROM version does not
@@ -78,19 +77,32 @@ void eepromWrite() {
   
   write(EE_ADDR, device_address);
   write(EE_NAME, *device_name, 10);
+  write(EE_LOAD_POS, ee_load_curPos);
+  write(EE_LOAD_START_STOP, ee_load_startStop);
+  write(EE_LOAD_END, ee_load_endPos);
 
 	byte tempMS = 0;
 	bool tempSleep = false;
-	
+	long tempPos = 0;
+	long tempStart = 0;
+	long tempStop = 0;
+	long tempEnd = 0;
+
 	for (int i = 0; i < MOTOR_COUNT; i++){
-		tempMS    = motor[i].ms();
-		tempSleep = motor[i].sleep();
+		tempMS		= motor[i].ms();
+		tempSleep	= motor[i].sleep();
+		tempPos		= motor[i].currentPos();
+		tempStart	= motor[i].startPos();
+		tempStop	= motor[i].stopPos();
+		tempEnd		= motor[i].endPos();
 		
-		write(EE_MS_0    + EE_MOTOR_MEMORY_SPACE * i, tempMS);
-		write(EE_SLEEP_0 + EE_MOTOR_MEMORY_SPACE * i, tempSleep);
-		
-	}
- 
+		write(EE_MS_0		+ EE_MOTOR_MEMORY_SPACE * i, tempMS);
+		write(EE_SLEEP_0	+ EE_MOTOR_MEMORY_SPACE * i, tempSleep);
+		write(EE_POS_0		+ EE_MOTOR_MEMORY_SPACE * i, tempPos);
+		write(EE_START_0	+ EE_MOTOR_MEMORY_SPACE * i, tempStart);
+		write(EE_STOP_0		+ EE_MOTOR_MEMORY_SPACE * i, tempStop);
+		write(EE_END_0		+ EE_MOTOR_MEMORY_SPACE * i, tempEnd);		
+	} 
 }
 
 
@@ -101,25 +113,52 @@ void eepromRestore() {
   
 	read(EE_ADDR, device_address);
 	read(EE_NAME, *device_name, 10);
+	read(EE_LOAD_POS, ee_load_curPos);
+	read(EE_LOAD_START_STOP, ee_load_startStop);
+	read(EE_LOAD_END, ee_load_endPos);
+
+	// Make sure garbage isn't saved to these vars if they haven't been saved to
+	// EEPROM before (e.g after initial loading of the firmware)
+	if (ee_load_curPos != 0 && ee_load_curPos != 1)
+		ee_load_curPos = 0;
+	if (ee_load_startStop != 0 && ee_load_startStop != 1)
+		ee_load_startStop = 0;
+	if (ee_load_endPos != 0 && ee_load_endPos != 1)
+		ee_load_endPos = 0;
 	
 	// There had been problems with reading the EEPROM values inside the motor setting functions,
 	// so as a work around, they are saved into these temporary variables which are then used to load
 	// the proper motor settings.
 	
-	byte tempMS = 0;
-	bool tempSleep = false;
+	byte tempMS		= 0;
+	bool tempSleep	= false;
+	long tempPos = 0;
+	long tempStart	= 0;
+	long tempStop	= 0;
+	long tempEnd	= 0;
 	
 	
 	for (int i = 0; i < MOTOR_COUNT; i++){
 
 		read(EE_MS_0    + EE_MOTOR_MEMORY_SPACE * i, tempMS);
 		read(EE_SLEEP_0 + EE_MOTOR_MEMORY_SPACE * i, tempSleep);
+		read(EE_POS_0	+ EE_MOTOR_MEMORY_SPACE * i, tempPos);
+		read(EE_START_0 + EE_MOTOR_MEMORY_SPACE * i, tempStart);
+		read(EE_STOP_0	+ EE_MOTOR_MEMORY_SPACE * i, tempStop);
+		read(EE_END_0	+ EE_MOTOR_MEMORY_SPACE * i, tempEnd);
 		
 		motor[i].ms(tempMS);
-		motor[i].sleep(tempSleep);		
-			
+		motor[i].sleep(tempSleep);
+		if (ee_load_curPos)
+			motor[i].currentPos(tempPos);
+		if (ee_load_startStop){
+			motor[i].startPos(tempStart);
+			motor[i].stopPos(tempStop);
+		}
+		if (ee_load_endPos){
+			endPos[i] = tempEnd;
+		}	
 	}
-
 }
 
 

--- a/Firmware/Motion_Engine/OM_EEPROM.ino
+++ b/Firmware/Motion_Engine/OM_EEPROM.ino
@@ -77,9 +77,6 @@ void eepromWrite() {
   
   write(EE_ADDR, device_address);
   write(EE_NAME, *device_name, 10);
-  write(EE_LOAD_POS, ee_load_curPos);
-  write(EE_LOAD_START_STOP, ee_load_startStop);
-  write(EE_LOAD_END, ee_load_endPos);
 
 	byte tempMS = 0;
 	bool tempSleep = false;
@@ -94,7 +91,7 @@ void eepromWrite() {
 		tempPos		= motor[i].currentPos();
 		tempStart	= motor[i].startPos();
 		tempStop	= motor[i].stopPos();
-		tempEnd		= motor[i].endPos();
+		tempEnd		= endPos[i];
 		
 		write(EE_MS_0		+ EE_MOTOR_MEMORY_SPACE * i, tempMS);
 		write(EE_SLEEP_0	+ EE_MOTOR_MEMORY_SPACE * i, tempSleep);

--- a/Firmware/Motion_Engine/OM_KeyFrameControl.ino
+++ b/Firmware/Motion_Engine/OM_KeyFrameControl.ino
@@ -143,10 +143,6 @@ void kf_startProgram(boolean isBouncePass){
 		if (!isBouncePass)
 			clearShotCounter();
 
-		// Take up any motor backlash		
-		takeUpBacklash();			
-				
-
 		// SMS Moves
 		if (Motors::planType() == SMS){
 			// Convert from "frames" to real milliseconds, based upon the camera interval						

--- a/Firmware/Motion_Engine/OM_Motor_Control.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Control.ino
@@ -158,9 +158,8 @@ void takeUpBacklash(boolean kf_move){
 			// Indicate that a brief pause is necessary after starting the motors
 			wait_required = true;
 
-			// Set the motor microsteps to low resolution and increase speed for fastest takeup possible
-			/*if (!graffikMode())
-				motor[i].ms(4);*/
+			// Set the motor microsteps to low resolution and increase speed for fastest takeup possible						
+			motor[i].ms(4);
 			
 			motor[i].contSpeed(mot_max_speed);
 						
@@ -184,8 +183,7 @@ void takeUpBacklash(boolean kf_move){
 
 	// Re-set all the motors to their proper microstep settings
 	for (byte i = 0; i < MOTOR_COUNT; i++) {
-		/*if (!graffikMode())
-			msAutoSet(i);*/
+		motor[i].restoreLastMs();
 
 		// Print debug info if proper flag is set
 		debug.funct("Microsteps: ");

--- a/Firmware/Motion_Engine/OM_Motor_Control.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Control.ino
@@ -556,8 +556,8 @@ void setJoystickSpeed(int p_motor, float p_speed){
 	if (abs(old_speed) < 1 && abs(new_speed) > 1 || ((old_speed / abs(old_speed)) != (new_speed / abs(new_speed)) && abs(new_speed) > 1)){
 		byte dir;
 		if (new_speed > 1)
-			dir = 1;
-		else
+			dir = 1;		
+		else if (new_speed < 1)
 			dir = 0;
 
 		motor[p_motor].continuous(true);

--- a/Firmware/Motion_Engine/OM_Motor_Control.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Control.ino
@@ -176,8 +176,9 @@ void takeUpBacklash(boolean kf_move){
 	// Can't wait when it's a keyframe move. For some reason this causes the controller to lock	
 	if (wait_required && !kf_move) {
 		unsigned long time = millis();
-		while (millis() - time < MILLIS_PER_SECOND){
-			// Wait a second for backlash takeup to finish
+		const int BACKLASH_WAIT = 300;
+		while (millis() - time < BACKLASH_WAIT){
+			// Wait for backlash takeup to finish
 		}
 	}
 

--- a/Firmware/Motion_Engine/OM_Motor_Travel.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Travel.ino
@@ -60,33 +60,34 @@ void sendToStart(uint8_t p_motor) {
 	else
 		motor[p_motor].programBackCheck(false);
 
-	//// Move at the maximum motor speed
-	//if (!graffikMode())
-	//	motor[p_motor].ms(4);
+	// Move at the maximum motor speed	
+	motor[p_motor].ms(4);
 	motor[p_motor].contSpeed(mot_max_speed);
 
 	// Start the move
 	motor[p_motor].moveToStart();
 	startISR();
+	motor[p_motor].setSending(true);
 }
 
-void sendToStop(uint8_t p_motor){
-
-	//// Move at the maximum motor speed
-	//if (!graffikMode())
-	//	motor[p_motor].ms(4);
+void sendToStop(uint8_t p_motor){	
+	// Move at the maximum motor speed		
+	motor[p_motor].ms(4);
 	motor[p_motor].contSpeed(mot_max_speed);
-
 	motor[p_motor].moveToStop();
 	startISR();
+	motor[p_motor].setSending(true);
 }
 
 void sendTo(uint8_t p_motor, long p_pos){
+	sendTo(p_motor, p_pos, false);
+}
+
+void sendTo(uint8_t p_motor, long p_pos, boolean kf_move){
 	
-	//// When not in Graffik Mode (i.e. App mode), use the lowest microsteps
-	//if (!graffikMode()){
-	//	motor[p_motor].ms(4);		
-	//}
+	// When not in Graffik Mode (i.e. App mode), use the lowest microsteps	
+	if (!kf_move)
+		motor[p_motor].ms(4);			
 
 	// Move at the maximum motor speed
 	debug.funct("Sending motor ");
@@ -100,4 +101,6 @@ void sendTo(uint8_t p_motor, long p_pos){
 	debug.funct("Continuous: ");
 	debug.functln(motor[p_motor].continuous());
 	startISR();
+	if (!kf_move)
+		motor[p_motor].setSending(true);
 }

--- a/Firmware/Motion_Engine/OM_Motor_Travel.ino
+++ b/Firmware/Motion_Engine/OM_Motor_Travel.ino
@@ -86,8 +86,11 @@ void sendTo(uint8_t p_motor, long p_pos){
 void sendTo(uint8_t p_motor, long p_pos, boolean kf_move){
 	
 	// When not in Graffik Mode (i.e. App mode), use the lowest microsteps	
-	if (!kf_move)
-		motor[p_motor].ms(4);			
+	if (!kf_move){
+		motor[p_motor].ms(4);
+		// Adjust the send location to match new microsteps
+		p_pos *= ((float)motor[p_motor].ms() / (float)motor[p_motor].lastMs());
+	}
 
 	// Move at the maximum motor speed
 	debug.funct("Sending motor ");

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -707,6 +707,16 @@ void serMain(byte command, byte* input_serial_buffer) {
 		break; 
 	}
 
+	//Command 33 requests that any motor backlash be taken up
+	case 33:
+	{	
+		takeUpBacklash();
+		msg = "Taking up motor backlash";
+		debugMessage(GEN, command, MSG);
+		response(true);
+		break;
+	}
+
 	//Command 50 sets Graffik Mode on or off
 	case 50:
 	{

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -456,7 +456,9 @@ void serMain(byte command, byte* input_serial_buffer) {
 		// send a motor home
 		for (byte i = 0; i < MOTOR_COUNT; i++){
 			motor[i].contSpeed(mot_max_speed);
+			motor[i].ms(4);			
 			motor[i].home();
+			motor[i].setSending(true);
 		}
 		startISR();
 		response(true);
@@ -1160,8 +1162,10 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 		thisMotor.contSpeed(mot_max_speed);
 
 		// send a motor home
+		thisMotor.ms(4);		
 		thisMotor.home();
 		startISR();
+		thisMotor.setSending(true);
 		response(true);
 		break;
 	}
@@ -1774,6 +1778,14 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 		debugMessage(subaddr, command, MSG, ratio);
 		response(true, (unsigned long)(ratio * 1e6));
 		break;
+	}
+	//Command 124 returns whether the motor is currently completing a "send to" command
+	case 124:
+	{
+		uint8_t sending = thisMotor.isSending() ? 1 : 0;
+		msg = "Is sending?: ";
+		debugMessage(subaddr, command, MSG, sending);
+		response(true, sending);
 	}
 
     //Error    

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -84,8 +84,6 @@ to respond to
 
   */
 
-long endPos[] = { 0, 0, 0 };
-
 char buffer[30];
 const PROGMEM char DIV[] = ": ";
 const PROGMEM char BUF0[] = " buf[0]: ";
@@ -669,11 +667,44 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 29 swaps all motors' start and stop positions
 	case 29:
 	{
-			   msg = "Setting Graffik mode: ";
-			   debugMessage(GEN, command, MSG, graffikMode());
-			   reverseStartStop();
-			   response(true);
-			   break;
+		msg = "Setting Graffik mode: ";
+		debugMessage(GEN, command, MSG, graffikMode());
+		reverseStartStop();
+		response(true);
+		break;
+	}
+
+	//Command 30 sets whether the current position should be saved after a power cycle
+	case 30:
+	{
+		msg = "Setting cur pos restore: ";
+		ee_load_curPos = input_serial_buffer[0];
+		OMEEPROM::write(EE_LOAD_POS, ee_load_curPos);
+		debugMessage(GEN, command, MSG, ee_load_curPos);		
+		response(true, ee_load_curPos);
+		break;
+	}
+
+	//Command 31 sets whether the start and stop points should be saved after a power cycle	
+	case 31:
+	{
+		msg = "Setting start/stop pos restore: ";
+		ee_load_startStop = input_serial_buffer[0];
+		OMEEPROM::write(EE_LOAD_START_STOP, ee_load_startStop);
+		debugMessage(GEN, command, MSG, ee_load_startStop);
+		response(true, ee_load_startStop);
+		break;
+	}
+
+	//Command 32 sets whether the end position should be saved after a power cycle
+	case 32:
+	{		
+		msg = "Setting end pos restore: ";
+		ee_load_endPos = input_serial_buffer[0];
+		OMEEPROM::write(EE_LOAD_END, ee_load_endPos);
+		debugMessage(GEN, command, MSG, ee_load_endPos);
+		response(true, ee_load_endPos);
+		break; 
 	}
 
 	//Command 50 sets Graffik Mode on or off
@@ -931,7 +962,7 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 126 returns whether the current program has completed
 	case 126:
 	{
-		boolean complete = programComplete();
+		uint8_t complete = programComplete() ? 1 : 0;
 		msg = "Is program complete?: ";
 		debugMessage(GEN, command, MSG, complete);		
 		response(true, complete);
@@ -964,7 +995,7 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 129 checks whether all the motors can achieve the required speed to complete program based on currently set parameters
 	case 129:
 	{
-		boolean isValid = validateProgram();
+		uint8_t isValid = validateProgram() ? 1 : 0;
 		msg = "Program valid?: ";
 		debugMessage(GEN, command, MSG, isValid);
 		response(true, isValid);
@@ -978,6 +1009,33 @@ void serMain(byte command, byte* input_serial_buffer) {
 		msg = "All motor sleep states: ";
 		debugMessage(GEN, command, MSG, motorSleep());
 		response(true, motorSleep());
+		break;
+	}
+
+	//Command 131 returns whether the current position should be saved after a power cycle
+	case 131:
+	{
+		msg = "Cur pos restore: ";			   
+		debugMessage(GEN, command, MSG, ee_load_curPos);
+		response(true, ee_load_curPos);
+		break;
+	}
+
+	//Command 132 returns whether the start and stop points should be saved after a power cycle	
+	case 132:
+	{
+		msg = "Start/stop pos restore: ";
+		debugMessage(GEN, command, MSG, ee_load_startStop);
+		response(true, ee_load_startStop);
+		break;
+	}
+
+	//Command 133 returns whether the end position should be saved after a power cycle
+	case 133:
+	{
+		msg = "End pos restore: ";
+		debugMessage(GEN, command, MSG, ee_load_endPos);
+		response(true, ee_load_endPos);
 		break;
 	}
 
@@ -1729,7 +1787,7 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 	//Command 118 returns whether the specified motor can achieve the speed required by the currently set program parameters
 	case 118:
 	{
-		boolean valid = validateProgram(subaddr - 1, false);
+		uint8_t valid = validateProgram(subaddr - 1, false) ? 1 : 0;
 		msg = "Is program valid? : ";
 		debugMessage(subaddr, command, MSG, valid);		
 		response(true, valid);

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -669,44 +669,11 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 29 swaps all motors' start and stop positions
 	case 29:
 	{
-		msg = "Setting Graffik mode: ";
-		debugMessage(GEN, command, MSG, graffikMode());
-		reverseStartStop();
-		response(true);
-		break;
-	}
-
-	//Command 30 sets whether the current position should be saved after a power cycle
-	case 30:
-	{
-		msg = "Setting cur pos restore: ";
-		ee_load_curPos = input_serial_buffer[0];
-		OMEEPROM::write(EE_LOAD_POS, ee_load_curPos);
-		debugMessage(GEN, command, MSG, ee_load_curPos);		
-		response(true, ee_load_curPos);
-		break;
-	}
-
-	//Command 31 sets whether the start and stop points should be saved after a power cycle	
-	case 31:
-	{
-		msg = "Setting start/stop pos restore: ";
-		ee_load_curPos = input_serial_buffer[0];
-		OMEEPROM::write(EE_LOAD_START_STOP, ee_load_startStop);
-		debugMessage(GEN, command, MSG, ee_load_startStop);
-		response(true, ee_load_startStop);
-		break;
-	}
-
-	//Command 32 sets whether the end position should be saved after a power cycle
-	case 32:
-	{		
-		msg = "Setting end pos restore: ";
-		ee_load_endPos = input_serial_buffer[0];
-		OMEEPROM::write(EE_LOAD_END, ee_load_endPos);
-		debugMessage(GEN, command, MSG, ee_load_endPos);
-		response(true, ee_load_endPos);
-		break; 
+			   msg = "Setting Graffik mode: ";
+			   debugMessage(GEN, command, MSG, graffikMode());
+			   reverseStartStop();
+			   response(true);
+			   break;
 	}
 
 	//Command 50 sets Graffik Mode on or off
@@ -964,7 +931,7 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 126 returns whether the current program has completed
 	case 126:
 	{
-		uint8_t complete = programComplete() ? 1 : 0;
+		boolean complete = programComplete();
 		msg = "Is program complete?: ";
 		debugMessage(GEN, command, MSG, complete);		
 		response(true, complete);
@@ -997,7 +964,7 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 129 checks whether all the motors can achieve the required speed to complete program based on currently set parameters
 	case 129:
 	{
-		uint8_t isValid = validateProgram() ? 1 : 0;
+		boolean isValid = validateProgram();
 		msg = "Program valid?: ";
 		debugMessage(GEN, command, MSG, isValid);
 		response(true, isValid);
@@ -1011,33 +978,6 @@ void serMain(byte command, byte* input_serial_buffer) {
 		msg = "All motor sleep states: ";
 		debugMessage(GEN, command, MSG, motorSleep());
 		response(true, motorSleep());
-		break;
-	}
-
-	//Command 131 returns whether the current position should be saved after a power cycle
-	case 131:
-	{
-		msg = "Cur pos restore: ";			   
-		debugMessage(GEN, command, MSG, ee_load_curPos);
-		response(true, ee_load_curPos);
-		break;
-	}
-
-	//Command 132 returns whether the start and stop points should be saved after a power cycle	
-	case 132:
-	{
-		msg = "Start/stop pos restore: ";
-		debugMessage(GEN, command, MSG, ee_load_startStop);
-		response(true, ee_load_startStop);
-		break;
-	}
-
-	//Command 133 returns whether the end position should be saved after a power cycle
-	case 133:
-	{
-		msg = "End pos restore: ";
-		debugMessage(GEN, command, MSG, ee_load_endPos);
-		response(true, ee_load_endPos);
 		break;
 	}
 
@@ -1789,7 +1729,7 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 	//Command 118 returns whether the specified motor can achieve the speed required by the currently set program parameters
 	case 118:
 	{
-		uint8_t valid = validateProgram(subaddr - 1, false) ? 1 : 0;
+		boolean valid = validateProgram(subaddr - 1, false);
 		msg = "Is program valid? : ";
 		debugMessage(subaddr, command, MSG, valid);		
 		response(true, valid);

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -1475,7 +1475,7 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 	//Command 30 sets the motor's stop position to its current position
 	case 30:
 	{
-		msg = "Stting stop here";
+		msg = "Setting stop here";
 		debugMessage(subaddr, command, MSG);
 		thisMotor.stopPos(thisMotor.currentPos());
 		response(true);
@@ -1680,8 +1680,15 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 	case 106:
 	{
 		msg = "Current pos: ";
-		debugMessage(subaddr, command, MSG, thisMotor.currentPos());
-		response(true, thisMotor.currentPos());
+		long curPos = thisMotor.currentPos();
+		/* 
+		 *	If the motor is being sent, it has automatically switched to 4th stepping without
+		 *  informing the master device, so it should adjust the position response durint this
+		 *  time to be consistent with its last known microstep settting.
+		 */
+		curPos = thisMotor.isSending() ? (thisMotor.lastMs() / thisMotor.ms()) * curPos : curPos;
+		debugMessage(subaddr, command, MSG, curPos);
+		response(true, curPos);
 		break;
 	}
 

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -669,11 +669,44 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 29 swaps all motors' start and stop positions
 	case 29:
 	{
-			   msg = "Setting Graffik mode: ";
-			   debugMessage(GEN, command, MSG, graffikMode());
-			   reverseStartStop();
-			   response(true);
-			   break;
+		msg = "Setting Graffik mode: ";
+		debugMessage(GEN, command, MSG, graffikMode());
+		reverseStartStop();
+		response(true);
+		break;
+	}
+
+	//Command 30 sets whether the current position should be saved after a power cycle
+	case 30:
+	{
+		msg = "Setting cur pos restore: ";
+		ee_load_curPos = input_serial_buffer[0];
+		OMEEPROM::write(EE_LOAD_POS, ee_load_curPos);
+		debugMessage(GEN, command, MSG, ee_load_curPos);		
+		response(true, ee_load_curPos);
+		break;
+	}
+
+	//Command 31 sets whether the start and stop points should be saved after a power cycle	
+	case 31:
+	{
+		msg = "Setting start/stop pos restore: ";
+		ee_load_curPos = input_serial_buffer[0];
+		OMEEPROM::write(EE_LOAD_START_STOP, ee_load_startStop);
+		debugMessage(GEN, command, MSG, ee_load_startStop);
+		response(true, ee_load_startStop);
+		break;
+	}
+
+	//Command 32 sets whether the end position should be saved after a power cycle
+	case 32:
+	{		
+		msg = "Setting end pos restore: ";
+		ee_load_endPos = input_serial_buffer[0];
+		OMEEPROM::write(EE_LOAD_END, ee_load_endPos);
+		debugMessage(GEN, command, MSG, ee_load_endPos);
+		response(true, ee_load_endPos);
+		break; 
 	}
 
 	//Command 50 sets Graffik Mode on or off
@@ -931,7 +964,7 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 126 returns whether the current program has completed
 	case 126:
 	{
-		boolean complete = programComplete();
+		uint8_t complete = programComplete() ? 1 : 0;
 		msg = "Is program complete?: ";
 		debugMessage(GEN, command, MSG, complete);		
 		response(true, complete);
@@ -964,7 +997,7 @@ void serMain(byte command, byte* input_serial_buffer) {
 	//Command 129 checks whether all the motors can achieve the required speed to complete program based on currently set parameters
 	case 129:
 	{
-		boolean isValid = validateProgram();
+		uint8_t isValid = validateProgram() ? 1 : 0;
 		msg = "Program valid?: ";
 		debugMessage(GEN, command, MSG, isValid);
 		response(true, isValid);
@@ -978,6 +1011,33 @@ void serMain(byte command, byte* input_serial_buffer) {
 		msg = "All motor sleep states: ";
 		debugMessage(GEN, command, MSG, motorSleep());
 		response(true, motorSleep());
+		break;
+	}
+
+	//Command 131 returns whether the current position should be saved after a power cycle
+	case 131:
+	{
+		msg = "Cur pos restore: ";			   
+		debugMessage(GEN, command, MSG, ee_load_curPos);
+		response(true, ee_load_curPos);
+		break;
+	}
+
+	//Command 132 returns whether the start and stop points should be saved after a power cycle	
+	case 132:
+	{
+		msg = "Start/stop pos restore: ";
+		debugMessage(GEN, command, MSG, ee_load_startStop);
+		response(true, ee_load_startStop);
+		break;
+	}
+
+	//Command 133 returns whether the end position should be saved after a power cycle
+	case 133:
+	{
+		msg = "End pos restore: ";
+		debugMessage(GEN, command, MSG, ee_load_endPos);
+		response(true, ee_load_endPos);
 		break;
 	}
 
@@ -1729,7 +1789,7 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 	//Command 118 returns whether the specified motor can achieve the speed required by the currently set program parameters
 	case 118:
 	{
-		boolean valid = validateProgram(subaddr - 1, false);
+		uint8_t valid = validateProgram(subaddr - 1, false) ? 1 : 0;
 		msg = "Is program valid? : ";
 		debugMessage(subaddr, command, MSG, valid);		
 		response(true, valid);

--- a/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
+++ b/Firmware/Motion_Engine/OM_Serial_Com_Client.ino
@@ -1464,6 +1464,7 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 		msg = "Setting units: ";
 		debugMessage(subaddr, command, MSG, unitCode);
 		thisMotor.units(unitCode);
+		response(true, unitCode);
 		break;
 	}
 	//Command 41 sets the gearbox ratio for this motor.
@@ -1473,6 +1474,7 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 		msg = "Setting gearbox ratio: ";
 		debugMessage(subaddr, command, MSG, ratio);
 		thisMotor.gboxRatio(ratio);
+		response(true, (unsigned long)(ratio * 1e6));
 		break;
 	}
 	//Command 42 sets the platform ratio for this motor. 
@@ -1482,6 +1484,7 @@ void serMotor(byte subaddr, byte command, byte* input_serial_buffer) {
 		msg = "Setting platform ratio: ";
 		debugMessage(subaddr, command, MSG, ratio);
 		thisMotor.platRatio(ratio);
+		response(true, (unsigned long)(ratio * 1e6));
 		break;
 	}
 

--- a/Web Updater/index.xml
+++ b/Web Updater/index.xml
@@ -213,6 +213,36 @@ Added saving feature for gearbox and platform ratio values
       </update>
 
 
+      <update>
+
+
+
+        <version>0.58 Beta</version>
+
+
+
+        <desc>4-14-16:
+
+
+
+Fixed missing responses for motor units, gbox ratio, and platform ratio setting commands.
+
+
+
+        </desc>
+
+
+
+        <file>http://download.dynamicperception.com/dpwu/nmx/0.58.hex</file>
+
+
+
+      </update>
+
+
+
+
+
 		</updates>
 
 	</device>


### PR DESCRIPTION
- When the controller receives a "send to" command, the motor temporarily changes to 4th stepping, then switches back to the last known microstep setting when the motor stops. During this time, the controller reports the position in the last known microstep setting, so as to not cause positional mismatch with the master device.

- A new command has been added (5.23) for manually requesting backlash takeup before a KF program.

- Start delay is now enabled for KF programs and is included in the maximum KF program time value (command 5.1.22)